### PR TITLE
Entity 설정 - (1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ local.properties
 .idea/**/dataSources/
 .idea/**/dataSources.ids
 .idea/**/dataSources.local.xml
+.idea/**/dataSources.xml
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml

--- a/.idea/modules/gusto.main.iml
+++ b/.idea/modules/gusto.main.iml
@@ -27,6 +27,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.springframework.boot:spring-boot-configuration-processor:3.2.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.projectlombok:lombok:1.18.30" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jpa:3.2.1" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jdbc:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-oauth2-client:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-security:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-web:3.2.1" level="project" />
@@ -35,6 +36,7 @@
     <orderEntry type="library" name="Gradle: org.hibernate.orm:hibernate-core:6.4.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-jpa:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-aspects:6.1.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-jdbc:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-config:6.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-oauth2-client:6.2.1" level="project" />
@@ -60,6 +62,7 @@
     <orderEntry type="library" name="Gradle: org.antlr:antlr4-runtime:4.13.0" level="project" />
     <orderEntry type="library" name="Gradle: jakarta.annotation:jakarta.annotation-api:2.1.1" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:2.0.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-relational:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-autoconfigure:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-logging:3.2.1" level="project" />
@@ -78,6 +81,7 @@
     <orderEntry type="library" name="Gradle: org.apache.tomcat.embed:tomcat-embed-core:10.1.17" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.tomcat.embed:tomcat-embed-el:10.1.17" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-jcl:6.1.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.jsqlparser:jsqlparser:4.6" level="project" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-classic:1.4.14" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.logging.log4j:log4j-to-slf4j:2.21.1" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:jul-to-slf4j:2.0.9" level="project" />
@@ -93,6 +97,7 @@
     <orderEntry type="library" name="Gradle: net.minidev:accessors-smart:2.5.0" level="project" />
     <orderEntry type="library" name="Gradle: org.ow2.asm:asm:9.3" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.springframework.boot:spring-boot-devtools:3.2.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: com.mysql:mysql-connector-j:8.1.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jboss.logging:jboss-logging:3.5.3.Final" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.hibernate.common:hibernate-commons-annotations:6.0.6.Final" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: io.smallrye:jandex:3.1.2" level="project" />

--- a/.idea/modules/gusto.test.iml
+++ b/.idea/modules/gusto.test.iml
@@ -18,6 +18,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="gusto.main" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jpa:3.2.1" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jdbc:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-oauth2-client:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-security:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-web:3.2.1" level="project" />
@@ -28,6 +29,7 @@
     <orderEntry type="library" name="Gradle: org.hibernate.orm:hibernate-core:6.4.1.Final" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-jpa:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-aspects:6.1.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-jdbc:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-config:6.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-oauth2-client:6.2.1" level="project" />
@@ -67,6 +69,7 @@
     <orderEntry type="library" name="Gradle: org.antlr:antlr4-runtime:4.13.0" level="project" />
     <orderEntry type="library" name="Gradle: jakarta.annotation:jakarta.annotation-api:2.1.1" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:2.0.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-relational:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-autoconfigure:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot:3.2.1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-logging:3.2.1" level="project" />
@@ -92,6 +95,7 @@
     <orderEntry type="library" name="Gradle: net.bytebuddy:byte-buddy-agent:1.14.10" level="project" />
     <orderEntry type="library" name="Gradle: com.vaadin.external.google:android-json:0.0.20131108.vaadin1" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-jcl:6.1.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.jsqlparser:jsqlparser:4.6" level="project" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-classic:1.4.14" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.logging.log4j:log4j-to-slf4j:2.21.1" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:jul-to-slf4j:2.0.9" level="project" />
@@ -107,6 +111,7 @@
     <orderEntry type="library" name="Gradle: org.opentest4j:opentest4j:1.3.0" level="project" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-core:1.4.14" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.logging.log4j:log4j-api:2.21.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Gradle: com.mysql:mysql-connector-j:8.1.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.glassfish.jaxb:jaxb-runtime:4.0.4" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.jboss.logging:jboss-logging:3.5.3.Final" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Gradle: org.hibernate.common:hibernate-commons-annotations:6.0.6.Final" level="project" />

--- a/gusto/build.gradle
+++ b/gusto/build.gradle
@@ -23,11 +23,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/gusto/src/main/java/com/umc/gusto/GustoApplication.java
+++ b/gusto/src/main/java/com/umc/gusto/GustoApplication.java
@@ -2,7 +2,9 @@ package com.umc.gusto;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GustoApplication {
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
@@ -1,0 +1,37 @@
+package com.umc.gusto.domain.group.entity;
+
+import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "GroupTable")
+public class Group extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "groupId", nullable = false, updatable = false)
+    private Long groupId;
+
+    @Column(nullable = false)
+    private String groupName;
+
+    private String groupScript;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner", nullable = false)
+    private User owner;
+
+    @Column(columnDefinition = "VARCHAR(50)")
+    private String notice;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/Group.java
@@ -7,6 +7,8 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -33,5 +35,11 @@ public class Group extends BaseEntity {
 
     @Column(columnDefinition = "VARCHAR(50)")
     private String notice;
+
+    @OneToMany(mappedBy = "group")
+    private List<GroupMember> groupMembers;
+
+    @OneToMany(mappedBy = "group")
+    private List<GroupList> groupLists;
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupList.java
@@ -1,0 +1,40 @@
+package com.umc.gusto.domain.group.entity;
+
+import com.umc.gusto.domain.store.entity.Store;
+import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class GroupList extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long groupListId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groupId", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId", nullable = false)
+    private Store store;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupList.java
@@ -4,13 +4,11 @@ import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseTime;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupMember.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupMember.java
@@ -3,13 +3,11 @@ package com.umc.gusto.domain.group.entity;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseTime;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupMember.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/GroupMember.java
@@ -1,0 +1,34 @@
+package com.umc.gusto.domain.group.entity;
+
+import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class GroupMember extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "groupMemberId", nullable = false, updatable = false)
+    private Long groupMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groupId", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
@@ -1,0 +1,32 @@
+package com.umc.gusto.domain.group.entity;
+
+import com.umc.gusto.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class InvitationCode extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long invitationCodeId;
+
+    @OneToOne
+    @JoinColumn(name = "groupId", nullable = false)
+    private Group group;
+
+    @Column(columnDefinition = "VARCHAR(6)")
+    private String code;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
@@ -2,13 +2,11 @@ package com.umc.gusto.domain.group.entity;
 
 import com.umc.gusto.global.common.BaseTime;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -4,15 +4,13 @@ import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -1,0 +1,39 @@
+package com.umc.gusto.domain.route.entity;
+
+import com.umc.gusto.domain.group.entity.Group;
+import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class Route extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long routeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groupId")
+    private Group group;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private String routeName;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -35,5 +37,8 @@ public class Route extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String routeName;
+
+    @OneToMany(mappedBy = "route")
+    private List<RouteList> routeLists;
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
@@ -1,0 +1,38 @@
+package com.umc.gusto.domain.route.entity;
+
+import com.umc.gusto.domain.store.entity.Store;
+import com.umc.gusto.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class RouteList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long routeListId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routeId", nullable = false)
+    private Route route;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId", nullable = false)
+    private Store store;
+
+    @Column(nullable = false)
+    private Integer ordinal;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
@@ -3,13 +3,11 @@ package com.umc.gusto.domain.route.entity;
 import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@EqualsAndHashCode
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Category.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Category.java
@@ -2,11 +2,9 @@ package com.umc.gusto.domain.store.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
+@EqualsAndHashCode
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Category.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Category.java
@@ -1,0 +1,23 @@
+package com.umc.gusto.domain.store.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class Category {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private Long categoryId;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private String categoryName;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
@@ -1,0 +1,26 @@
+package com.umc.gusto.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class City {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long cityId;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private String cityCode;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private String cityName;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
@@ -1,11 +1,9 @@
 package com.umc.gusto.domain.store.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
+@EqualsAndHashCode
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/State.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/State.java
@@ -1,0 +1,26 @@
+package com.umc.gusto.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class State {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long stateId;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private String stateCode;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private String stateName;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/State.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/State.java
@@ -1,11 +1,9 @@
 package com.umc.gusto.domain.store.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
+@EqualsAndHashCode
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -2,13 +2,11 @@ package com.umc.gusto.domain.store.entity;
 
 import com.umc.gusto.global.common.BaseTime;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -1,0 +1,66 @@
+package com.umc.gusto.domain.store.entity;
+
+import com.umc.gusto.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class Store extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long storeId;
+
+    @Column(columnDefinition = "VARCHAR(30)")
+    private String storeName;
+
+    private Float longtitude;
+
+    private Float latitude;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "categoryId")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "stateId", nullable = false)
+    private State state;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "cityId", nullable = false)
+    private City city;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "townId", nullable = false)
+    private Town town;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(60)")
+    private String address;
+
+    @Column(columnDefinition = "VARCHAR(60)")
+    private String oldAddress;
+
+    @Column(columnDefinition = "VARCHAR(20)")
+    private String contact;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 10)
+    private StoreStatus storeStatus = StoreStatus.ACTIVE;
+
+    public enum StoreStatus {
+        ACTIVE, INACTIVE, CLOSED
+    }
+
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
@@ -1,0 +1,25 @@
+package com.umc.gusto.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class Town {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private Long townId;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private String townCode;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private String townName;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
@@ -1,11 +1,9 @@
 package com.umc.gusto.domain.store.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
+@EqualsAndHashCode
 @Entity
 @Getter
 @Builder

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -1,16 +1,15 @@
 package com.umc.gusto.domain.user.entity;
 
+import com.umc.gusto.global.common.BaseTime;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.UUID;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Getter
 @Builder
@@ -19,7 +18,7 @@ import java.util.UUID;
 @DynamicInsert
 @DynamicUpdate
 @Table(name = "User")
-public class User {
+public class User extends BaseTime {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name="uuid2", strategy = "uuid2")

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -1,0 +1,29 @@
+package com.umc.gusto.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "User")
+public class User {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name="uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID userid;
+
+}

--- a/gusto/src/main/java/com/umc/gusto/global/common/BaseEntity.java
+++ b/gusto/src/main/java/com/umc/gusto/global/common/BaseEntity.java
@@ -1,0 +1,18 @@
+package com.umc.gusto.global.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTime{
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 10)
+    protected Status status = Status.ACTIVE;
+
+    public enum Status {
+        ACTIVE, INACTIVE;
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/global/common/BaseTime.java
+++ b/gusto/src/main/java/com/umc/gusto/global/common/BaseTime.java
@@ -1,0 +1,24 @@
+package com.umc.gusto.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime{
+    @CreationTimestamp
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updatedAt", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 일부 entity 초기 설정 #2 
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :   


### 작업 내역
- 작업 특이사항
  - Entity 생성만 담긴 기초 세팅이기에 main 브랜치에 그대로 작업했습니다.
  - 일부 필드명을 코드 컨텍스트에 맞게 수정하였으며, 수정된 필드명은 erd 설계도에 반영해두었습니다.
  - 연관관계 설정 시 User Entity가 필요하여 class 생성 및 어노테이션 처리, id만 작성하여 사용했습니다.
  - `VARCHAR` 필드의 경우 길이에 대해 PM과 협의 후 전반적인 수정 및 확정이 필요합니다.
  
- BaseTime / BaseEntity

    > - `BaseEntity`가 `BaseTime`을 상속하도록 하였으며, 각 엔티티는 설계에 맞춰 `BaseTime `혹은 `BaseEntity`를 상속합니다.
    > - 특히, status enum의 형태가 `ACTIVE`/`INACTIVE` 만 존재하는 경우 별개의 필드를 갖지 않고 `BaseEntity`를 사용합니다.

- Store Entity 
  - address einties  
  
    > 해당 엔티티들의 `VARCHAR` 길이는 임의로 설정되었으며, 행정구역 코드를 결정하는 대로 수정이 필요합니다.
  - Category Entity
- Route Entity

    > - Route에서 RouteList를 조회할 수 있도록 양방향 매핑을 설정했습니다.
    > - RouteList Entity

- Group Entity

    >   - `Group`의 경우 MySQL의 예약어로, 충돌을 피하기 위해 엔티티의 저장명은 `group_table`로 하였습니다. Spring 내에서는 Group을 그대로 사용합니다.
    >   - Group에서 `GroupList` 및 `GroupMember`를 조회할 수 있도록 양방향 매핑을 설정했습니다.
    >   - `InvitationCode`의 경우 `Group`과 `1:1` 관계로, 해당 관계에서 양방향 매핑 설정 시 `fetch` 기준이 `EAGER`가 되어 양방향 매핑을 설정하지 않았습니다.

  - GroupList Entity
  - GroupMember Entity
  - InvitationCode Entity  
  
 
### PR 특이사항
- 해당 PR에서 OpeningHours entity가 생성될 예정이었으나, 보류되었습니다. 관련사항 이슈 확인 부탁드립니다.


### Issue Number 

close: #2 
