### PR TITLE
feat : RestControllor를 이용한 에러 핸들러

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -1,0 +1,18 @@
+package com.umc.gusto.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum Code {
+    INTERNAL_SEVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 에러 발생, 관리자에게 문의해주세요."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST,41000, "잘못된 요청입니다."),
+    NO_PERMISSION(HttpStatus.BAD_REQUEST,41001, "해당 권한이 없습니다."),
+    FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/gusto/src/main/java/com/umc/gusto/global/exception/ExceptionResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/ExceptionResponse.java
@@ -1,0 +1,11 @@
+package com.umc.gusto.global.exception;
+
+public record ExceptionResponse<T>(
+        boolean success,
+        int errorCode,
+        String message
+) {
+    public static <T> ExceptionResponse<T> from(Code code){
+        return new ExceptionResponse<>(false,code.getCode(), code.getMessage());
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/global/exception/GeneralException.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/GeneralException.java
@@ -1,0 +1,12 @@
+package com.umc.gusto.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+    private Code code;
+}

--- a/gusto/src/main/java/com/umc/gusto/global/exception/customException/TempException.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/customException/TempException.java
@@ -1,0 +1,10 @@
+package com.umc.gusto.global.exception.customException;
+
+import com.umc.gusto.global.exception.Code;
+import com.umc.gusto.global.exception.GeneralException;
+
+public class TempException extends GeneralException {
+    public TempException(Code errorCode){
+        super(errorCode);
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/global/exception/handler/GlobalExceptionHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.umc.gusto.global.exception.handler;
+
+import com.umc.gusto.global.exception.Code;
+import com.umc.gusto.global.exception.ExceptionResponse;
+import com.umc.gusto.global.exception.GeneralException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice(annotations = {RestController.class})
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, Code.valueOf(errorMessage), request);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+        return handleExceptionInternalFalse(e, Code.INTERNAL_SEVER_ERROR, request);
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity customException(GeneralException generalException, HttpServletRequest request) {
+        Code errorCode = generalException.getCode();
+        return handleExceptionInternal(generalException,errorCode,null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, Code errorCode, HttpHeaders httpHeader,HttpServletRequest request) {
+
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(e, body, httpHeader, errorCode.getHttpStatus(), webRequest);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, Code errorCode, WebRequest request) {
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+        return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorCode.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, Code errorCode, WebRequest request) {
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+        return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorCode.getHttpStatus(), request);
+    }
+
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 :
에러 핸들러 생성
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
예외 발생 시 응답 형태는 아래와 같도록 했습니다. 
```
{ 
  "success": false,
  "errorCode": 4100,
  "message": "잘못된 요청입니다."
}
```
예외 응답은 변경이 필요없기 때문에 record로 만들어서 데이터 가공 시 중간에 변질될 우려가 없도록 했습니다. 

### Issue Number 
연관된 Issue: #19 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
저희가 응답 형태를 의논하지 않아서 다들 아는 워크북을 기준으로 에러핸들러를 수정해서 만들었습니다. 
하지만,  에러 핸들러를 공부하다보니 정해야하는 부분이 있는 것 같아 노션에 정리해두겠습니다.
노션 문서를 보시고 의견을 주시면 코드를 수정하도록 하겠습니다!

