### PR TITLE
fix: 소셜 로그인 동의 여부 관련 버그, provider Id가 노출되던 문제

### DIFF
--- a/gusto/build.gradle
+++ b/gusto/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
@@ -44,9 +44,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
             response.setHeader("temp-token", String.valueOf(socialInfo.getTemporalToken()));
 
             // TODO: 차후 응답 코드 형태 맞춰 리팩토링할 것
-            String body = """
-                    { "isSuccess" : true, "code" : 302, "message" : "회원가입을 진행해야 합니다.", "result" : """
-                    + objectMapper.writeValueAsString(oAuth2User.getOAuthAttributes()) + "}";
+            String body = objectMapper.writeValueAsString(oAuth2User.getOAuthAttributes());
 
             response.getWriter().write(body);
         }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
@@ -47,7 +47,7 @@ public class OAuthService extends DefaultOAuth2UserService {
         }
 
         if(info.getSocialStatus() == Social.SocialStatus.DISCONNECTED) {
-            // error throw
+            // TODO: error throw
         }
 
         return CustomOAuth2User.builder()

--- a/gusto/src/main/java/com/umc/gusto/global/auth/model/OAuthAttributes.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/model/OAuthAttributes.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.global.auth.model;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.umc.gusto.domain.user.entity.Social;
 import com.umc.gusto.domain.user.entity.User;
 import lombok.*;
@@ -13,6 +14,7 @@ import java.util.Optional;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OAuthAttributes {
+    @JsonIgnore
     private String id;
     private String nickname;
     private String profileImg;

--- a/gusto/src/main/java/com/umc/gusto/global/auth/model/OAuthAttributes.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/model/OAuthAttributes.java
@@ -6,6 +6,7 @@ import com.umc.gusto.domain.user.entity.User;
 import lombok.*;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Builder
 @Getter
@@ -36,28 +37,31 @@ public class OAuthAttributes {
 
         // Gender & Age-range의 경우 provider에 따라 제공 방법이 다르므로 개별 파싱
         // 여러 provider 연결 이후 개선 예정
-        String providedGender = (String) response.get("gender");
+        Optional<String> providedGender = Optional.ofNullable((String) response.get("gender"));
+
         oAuthAttributes.gender = User.Gender.NONE;
-        if(providedGender.equals("F"))
-            oAuthAttributes.gender = User.Gender.FEMALE;
-        else if(providedGender.equals("M"))
-            oAuthAttributes.gender = User.Gender.MALE;
 
-        String providedAge = (String) response.get("age");
-        providedAge = providedAge.substring(0, providedAge.indexOf("-"));
+        providedGender.ifPresent(gender -> {
+            if(gender.equals("F"))
+                oAuthAttributes.gender = User.Gender.FEMALE;
+            else if(gender.equals("M"))
+                oAuthAttributes.gender = User.Gender.MALE;
+        });
 
-        switch (Integer.valueOf(providedAge)) {
-            case 10 -> oAuthAttributes.age = User.Age.TEEN;
-            case 20 -> oAuthAttributes.age = User.Age.TWENTIES;
-            case 30 -> oAuthAttributes.age = User.Age.THIRTIES;
-            case 40 -> oAuthAttributes.age = User.Age.FOURTIES;
-            case 50 -> oAuthAttributes.age = User.Age.FIFTIES;
-            default -> oAuthAttributes.age = User.Age.NONE;
-        }
+        Optional<String> providedAge = Optional.ofNullable((String) response.get("age"));
+        oAuthAttributes.age = User.Age.NONE;
 
-        if(Integer.valueOf(providedAge) >= 60) {
-            oAuthAttributes.age = User.Age.OLDER;
-        }
+        providedAge.ifPresent(age -> {
+            switch (Integer.valueOf(age)) {
+                case 0 -> oAuthAttributes.age = User.Age.NONE;
+                case 10 -> oAuthAttributes.age = User.Age.TEEN;
+                case 20 -> oAuthAttributes.age = User.Age.TWENTIES;
+                case 30 -> oAuthAttributes.age = User.Age.THIRTIES;
+                case 40 -> oAuthAttributes.age = User.Age.FOURTIES;
+                case 50 -> oAuthAttributes.age = User.Age.FIFTIES;
+                default -> oAuthAttributes.age = User.Age.OLDER;
+            }
+        });
 
         return oAuthAttributes;
     }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
  - 소셜 로그인 시 정보 제공 항목 일부 미동의 시 NPE(NullPointException)이 발생하던 문제
  - 최초 로그인 시 user의 소셜 정보에 provider의 user 식별자가 노출되던 문제
- [x] 리펙토링
  - 최초 로그인 시 반환하는 response body의 구조를 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 소셜 로그인 시 정보 제공 항목 일부 미동의 시 버그가 발생하던 문제
  - Optional class를 활용하여 NPE가 발생할 수 있는 resource를 명시
  - Optional.ifPresent() 를 사용, null이 아닌 경우에만 데이터 parsing을 진행
- 최초 로그인 시 user의 소셜 정보에 provider의 user 식별자가 노출되던 문제
  - `@JsonIgnore` 어노테이션을 활용하여 json 직렬화 시 id 값을 제외
- 최초 로그인 시 반환하는 response body의 구조를 변경
  - 기존 항목의 `result`에 해당하는 값만 return 하도록 변경

### Issue Number 

close: #21
