### PR TITLE
feat: 랜덤 닉네임 생성

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/UserService.java
@@ -14,4 +14,7 @@ public interface UserService {
 
     // 닉네임 사용 확정 - 회원 가입 시
     void confirmNickname(String nickname);
+
+    // 닉네임 랜덤 생성
+    String generateRandomNickname();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.gusto.domain.user;
 
 import com.umc.gusto.domain.user.entity.Social;
 import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.domain.user.model.NicknameBucket;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.repository.UserRepository;
 import com.umc.gusto.global.auth.JwtService;
@@ -25,11 +26,14 @@ public class UserServiceImpl implements UserService{
     private final SocialRepository socialRepository;
     private final JwtService jwtService;
     private final RedisService redisService;
+
     private static final long NICKNAME_EXPIRED_TIME = 1000L * 60 * 15;
+    private int MAX_NICKNAME_NUMBER = 999;
+    private int MIN_NICKNAME_NUMBER = 1;
 
 
     @Value("${default.img.url.profile}")
-    private String DEFAULT_IMG;
+    private static String DEFAULT_IMG;
 
 
     @Override
@@ -97,5 +101,27 @@ public class UserServiceImpl implements UserService{
         redisService.setValuesWithTimeout(nickname, "null", NICKNAME_EXPIRED_TIME);
     }
 
+    public String generateRandomNickname() {
+        String nickname = null;
 
+        // 중복 없는 닉네임이 생성될 때까지 반복
+        while (true) {
+            try {
+                // 단어 두 개 선택
+                String[] nicknames = NicknameBucket.getNicknames();
+
+                // MIN_NICKNAME_NUMBER : 1 ~ MAX_NICKNAME_NUMBER : 999 까지 수 중 랜덤 수 생성
+                int random = (int) (Math.random() * (MAX_NICKNAME_NUMBER - MIN_NICKNAME_NUMBER) + MIN_NICKNAME_NUMBER);
+
+                nickname = nicknames[0] + " " + nicknames[1] + " " + String.valueOf(random);
+
+                checkNickname(nickname);
+            } catch (RuntimeException e) {
+                continue;
+            }
+            break;
+        }
+
+        return nickname;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/NicknameBucket.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/NicknameBucket.java
@@ -1,0 +1,29 @@
+package com.umc.gusto.domain.user.model;
+
+public final class NicknameBucket {
+    public static final String[] bucketA = {
+            "귀여운", "용맹한", "용감한", "엘레강스한", "웃기는",
+            "즐거운", "청량한", "고지식한", "산뜻한", "똑똑한",
+            "명랑한", "상쾌한", "깨끗한", "노래하는", "소심한",
+            "의심하는", "어지러운", "혼란스러운", "빛나는", "천진난만한"
+    };
+    public static final String[] bucketB = {
+            "파스타", "뇨끼", "비빔밥", "곰탕", "감자탕",
+            "수플레", "짬뽕", "탕수육", "야채곱창", "피자",
+            "샐러드", "족발", "바질페스토", "도토리묵", "전복죽",
+            "계란말이", "닭볶음탕", "추어탕", "단팥빵", "치즈케이크",
+            "에그타르트"
+    };
+
+    public static int indexA = 0;
+    public static int indexB = 0;
+
+    public static String[] getNicknames() {
+        String[] nicknames = new String[] {bucketA[indexA], bucketB[indexB]};
+
+        indexA = (indexA + 1) % bucketA.length; // bucketA는 index 1씩 이동
+        indexB = (indexB + 1) % bucketB.length; // bucketB는 index 3씩 이동
+
+        return nicknames;
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FirstLogInResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FirstLogInResponse.java
@@ -1,0 +1,8 @@
+package com.umc.gusto.domain.user.model.response;
+
+public record FirstLogInResponse (
+    String nickname,
+    String profileImg,
+    String gender,
+    String age
+) { }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private final ObjectMapper objectMapper;
     private final JwtService jwtService;
+    private final OAuthService oAuthService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -44,9 +45,9 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
             response.setHeader("temp-token", String.valueOf(socialInfo.getTemporalToken()));
 
             // TODO: 차후 응답 코드 형태 맞춰 리팩토링할 것
-            String body = """
-                    { "isSuccess" : true, "code" : 302, "message" : "회원가입을 진행해야 합니다.", "result" : """
-                    + objectMapper.writeValueAsString(oAuth2User.getOAuthAttributes()) + "}";
+            String body = objectMapper.writeValueAsString(
+                    oAuthService.generateFirstLogInRes(oAuth2User.getOAuthAttributes())
+            );
 
             response.getWriter().write(body);
         }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
@@ -1,7 +1,9 @@
 package com.umc.gusto.global.auth;
 
 import com.umc.gusto.domain.user.SocialRepository;
+import com.umc.gusto.domain.user.UserService;
 import com.umc.gusto.domain.user.entity.Social;
+import com.umc.gusto.domain.user.model.response.FirstLogInResponse;
 import com.umc.gusto.global.auth.model.CustomOAuth2User;
 import com.umc.gusto.global.auth.model.OAuthAttributes;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OAuthService extends DefaultOAuth2UserService {
     private final SocialRepository socialRepository;
+    private final UserService userService;
+
     // 유저 불러오기 - 해당 유저의 security context가 저장됨
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -55,5 +59,18 @@ public class OAuthService extends DefaultOAuth2UserService {
                 .oAuthAttributes(oAuthAttributes)
                 .socialInfo(info)
                 .build();
+    }
+
+    public FirstLogInResponse generateFirstLogInRes(OAuthAttributes oAuthAttributes) {
+        String nickname = oAuthAttributes.getNickname();
+
+        if(nickname == null) {
+            nickname = userService.generateRandomNickname();
+        }
+
+        return new FirstLogInResponse(nickname,
+                oAuthAttributes.getProfileImg(),
+                oAuthAttributes.getGender().name(),
+                oAuthAttributes.getAge().name());
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 회원가입 시 return 되는 default 랜덤 닉네임 생성 기능
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 랜덤 닉네임 생성 로직
  - 중복 닉네임 생성을 최대한 방지하기 위해 Default 닉네임의 모든 요소를 랜덤하게 선택하지 않고,
  `형용사` 풀과 `메뉴명` 풀이 각각 회전하도록 하였습니다.
  - 현재 `형용사` 풀(bucketA) 에는 20개의 item이, `메뉴명` 풀(bucketB)에는 21개의 item이 존재합니다.
    - `bucketA`
      ```java
      public static final String[] bucketA = {
            "귀여운", "용맹한", "용감한", "엘레강스한", "웃기는",
            "즐거운", "청량한", "고지식한", "산뜻한", "똑똑한",
            "명랑한", "상쾌한", "깨끗한", "노래하는", "소심한",
            "의심하는", "어지러운", "혼란스러운", "빛나는", "천진난만한"
      };
      ``` 
    - `bucketB`
      ```java
      public static final String[] bucketB = {
            "파스타", "뇨끼", "비빔밥", "곰탕", "감자탕",
            "수플레", "짬뽕", "탕수육", "야채곱창", "피자",
            "샐러드", "족발", "바질페스토", "도토리묵", "전복죽",
            "계란말이", "닭볶음탕", "추어탕", "단팥빵", "치즈케이크",
            "에그타르트"
      };
      ``` 
  - 해당 bucket들을 한칸씩 슬라이딩하여 메뉴명을 조합하게 되면, 20과 21이 서로소(공약수가 1 뿐인 수) 관계에 있으므로 20 * 21개의 가능한 모든 경우의 수가 조합된 뒤에 최초 닉네임(`귀여운 파스타`)과 동일한 닉네임이 생성됩니다.
  - 위의 로직으로 생성된 닉네임에 1부터 999까지의 랜덤 난수를 생성해 붙여 최종 닉네임을 완성합니다.
- 생성된 닉네임은 중복체크를 거친 뒤 회원가입을 희망하는 유저에게 전달됩니다.

### 특이 사항

- 닉네임 버킷 풀의 item의 수는 변동될 가능성이 있습니다! (단, 두 수가 서로소 관계에 있는 것은 변하지 않습니다)


### Issue Number 

close: #23, #11

