### PR TITLE
fix: 닉네임 중복체크 API의 method 변경(POST -> GET)

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -41,11 +41,11 @@ public class UserController {
 
     /**
      * 닉네임 중복 체크 API
-     * [POST] /users/check-nickname/{nickname}
+     * [GET] /users/check-nickname/{nickname}
      * @param nickname
      * @return -
      */
-    @PostMapping("/check-nickname/{nickname}")
+    @GetMapping("/check-nickname/{nickname}")
     public ResponseEntity checkNickname(@PathVariable("nickname")String nickname) {
         checkNickname(nickname);
 


### PR DESCRIPTION
API 설계서와 다르게 작성되었음

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 닉네임 중복체크 API의 method를 POST에서 GET으로 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- API 설계서(GET)과 다르게 작성되었음.

### PR 특이 사항

- `@PostMapping`에서 `@GetMapping`으로 변경하는 단순 작업이므로 별도의 approve 없이 바로 merge