### PR TITLE
refactor:  단일 이미지, 다수 이미지 로직 분리 

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -59,7 +59,8 @@ public class RouteServiceImpl implements RouteService{
 
     @Override
     public List<RouteResponse.RouteResponseDto> getRoute(String nickname) {
-        User user = userRepository.findByNickname(nickname);
+        User user = userRepository.findByNicknameAndMemberStatus(nickname, User.MemberStatus.ACTIVE)
+                .orElseThrow(()-> new RuntimeException("존재하지 않는 회원입니다."));
 
         List<Route> routes = routeRepository.findRouteByUser(user);
         return routes.stream().map(

--- a/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.umc.gusto.domain.store.repository;
+
+import com.umc.gusto.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store,Long> {
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
@@ -3,8 +3,11 @@ package com.umc.gusto.domain.user.repository;
 import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
     Long countUsersByNicknameAndMemberStatusIs(String nickname, User.MemberStatus status);
+
+    Optional<User> findByNicknameAndMemberStatus(String nickname,User.MemberStatus status);
 }

--- a/gusto/src/main/java/com/umc/gusto/global/util/S3Controller.java
+++ b/gusto/src/main/java/com/umc/gusto/global/util/S3Controller.java
@@ -3,9 +3,7 @@ package com.umc.gusto.global.util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -17,12 +15,25 @@ public class S3Controller {
 
     private final S3Service imageService;
 
-    @PostMapping()
+    @PostMapping("/list")
     public ResponseEntity<List<String>> uploadImages(
             @RequestPart(value = "file", required = false) List<MultipartFile> images) {
         List<String> fileUrls = imageService.uploadImages(images);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(fileUrls);
     }
 
+    @PostMapping()
+    public ResponseEntity<String> uploadImage(
+            @RequestPart(value = "file", required = false) MultipartFile image){
+        String url = imageService.uploadImage(image);
+        return ResponseEntity.ok().body(url);
+    }
+
+    @DeleteMapping("/{fileName}")
+    public ResponseEntity<Void> deleteImage(
+            @PathVariable("fileName") String fileName) { // 파일 삭제 시 .png까지 포함하여 fileName으로 작성
+        imageService.deleteImage(fileName);
+        return ResponseEntity.ok().build();
+    }
 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 테스트 편리성을 위해 이미지 삭제 코드 추가
- [ ] 버그 수정 :
- [x] 리펙토링 : 이미지 저장 로직 분리(단일,다수)
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- #39 에서 프로필 이미지처럼 단일 이미지만 저장하는 경우 List에서 값을 한 번 더 가져오는 로직이 필요함으로 이를 해소하기 위함 추가 작업을 진행했습니다. 

### 작업 내역
- 테스트 후 이미지 편리한 삭제를 위해 로그에 파일명이 출력됩니다.랜덤값.png로 확장자까지 이름에 포함됩니다.
- uploadImages()를 통해 다수의 이미지를 저장
- uploadImage()로 단일 이미지를 저장

### Issue Number 

close: #53 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
<의견이 필요한 부분>
1.S3 업로드 실패도 GeneralException을 사용할까요?
2. 이미지만 저장하기 위해 현재 s3버킷 정책을 설정하는데, 코드에서 확장자 처리를 하면 에러 발생 시 메세지가 나오지만 버킷은 정책 외에 확장자는 빼고 저장합니다. 버킷 정책과 코드 중 어떤 방법으로 확정할 것인지 고민입니다. 
