### PR TITLE
feat: Group 목록 및 구성원 조회 API

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.group.controller;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
+import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.user.entity.User;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,6 +63,17 @@ public class GroupController {
         User owner = authUser.getUser();
         groupService.deleteGroup(owner, groupId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * 그룹 목록 조회
+     * [GET] /groups
+     */
+    @GetMapping
+    public ResponseEntity<List<GetGroupsResponse>> getGroups(@AuthenticationPrincipal AuthUser authUser){
+        User user = authUser.getUser();
+        List<GetGroupsResponse> groups = groupService.getUserGroups(user);
+        return ResponseEntity.status(HttpStatus.OK).body(groups);
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package com.umc.gusto.domain.group.controller;
 
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
+import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
@@ -72,8 +73,18 @@ public class GroupController {
     @GetMapping
     public ResponseEntity<List<GetGroupsResponse>> getGroups(@AuthenticationPrincipal AuthUser authUser){
         User user = authUser.getUser();
-        List<GetGroupsResponse> groups = groupService.getUserGroups(user);
-        return ResponseEntity.status(HttpStatus.OK).body(groups);
+        List<GetGroupsResponse> getGroups = groupService.getUserGroups(user);
+        return ResponseEntity.status(HttpStatus.OK).body(getGroups);
+    }
+
+    /**
+     * 그룹 구성원 조회
+     * [GET] /groups/{groupId}/members
+     */
+    @GetMapping("/{groupId}/members")
+    public ResponseEntity<List<GetGroupMemberResponse>> getGroupMembers (@PathVariable Long groupId){
+        List<GetGroupMemberResponse> getGroupMembers = groupService.getGroupMembers(groupId);
+        return ResponseEntity.status(HttpStatus.OK).body(getGroupMembers);
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetGroupsResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetGroupsResponse.java
@@ -1,0 +1,18 @@
+package com.umc.gusto.domain.group.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetGroupsResponse {
+    Long groupId;
+    String groupName;
+    Integer numMembers;
+    Integer numRestaurants;
+    Integer numRoutes;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
@@ -1,0 +1,9 @@
+package com.umc.gusto.domain.group.repository;
+
+import com.umc.gusto.domain.group.entity.Group;
+import com.umc.gusto.domain.group.entity.GroupList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupListRepository extends JpaRepository<GroupList, Long> {
+    int countGroupListsByGroup(Group group);
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -13,4 +13,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     List<GroupMember> findGroupMembersByGroup(Group group);
     @Query("SELECT gm.groupMemberId FROM GroupMember gm WHERE gm.group = :group AND gm.user = :user")
     Long findGroupMemberIdByGroupAndUser(Group group, User user);
+    @Query("SELECT gm.group.groupId FROM GroupMember gm WHERE gm.user = :user")
+    List<Long> findGroupIdsByUser(User user);
+    int countGroupMembersByGroup(Group group);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findGroupByGroupId(Long groupId);
     Optional<Group> findGroupByGroupIdAndStatus(Long groupId, BaseEntity.Status status);
+    List<Group> findGroupsByGroupIdInAndStatus(List<Long> groupIds, BaseEntity.Status status);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -2,6 +2,7 @@ package com.umc.gusto.domain.group.service;
 
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
+import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
@@ -24,4 +25,7 @@ public interface GroupService {
 
     // 그룹 목록 조회
     List<GetGroupsResponse> getUserGroups(User user);
+
+    //그룹 구성원 조회
+    List<GetGroupMemberResponse> getGroupMembers(Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -3,8 +3,11 @@ package com.umc.gusto.domain.group.service;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
+import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.user.entity.User;
+
+import java.util.List;
 
 public interface GroupService {
     // 그룹 생성
@@ -18,4 +21,7 @@ public interface GroupService {
 
     // 그룹 삭제
     void deleteGroup(User owner, Long groupId);
+
+    // 그룹 목록 조회
+    List<GetGroupsResponse> getUserGroups(User user);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -52,14 +52,7 @@ public class GroupServiceImpl implements GroupService{
         Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
                 .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
         Long ownerMemberId = groupMemberRepository.findGroupMemberIdByGroupAndUser(group, group.getOwner());
-        List<GroupMember> groupMembers = groupMemberRepository.findGroupMembersByGroup(group);
-        List<GetGroupMemberResponse> groupMembersDto = groupMembers.stream()
-                .map(member -> new GetGroupMemberResponse(
-                        member.getGroupMemberId(),
-                        member.getUser().getNickname(),
-                        member.getUser().getProfileImage()
-                ))
-                .collect(Collectors.toList());
+        List<GetGroupMemberResponse> groupMembersDto = getGroupMembers(groupId);
         return GetGroupResponse.builder()
                 .groupId(group.getGroupId())
                 .groupName(group.getGroupName())
@@ -131,6 +124,20 @@ public class GroupServiceImpl implements GroupService{
                             .numRoutes(numRoutes)
                             .build();
                 })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetGroupMemberResponse> getGroupMembers(Long groupId){
+        Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
+        List<GroupMember> groupMembers = groupMemberRepository.findGroupMembersByGroup(group);
+        return groupMembers.stream()
+                .map(groupMember -> GetGroupMemberResponse.builder()
+                        .groupMemberId(groupMember.getGroupMemberId())
+                        .nickname(groupMember.getUser().getNickname())
+                        .profileImg(groupMember.getUser().getProfileImage())
+                        .build())
                 .collect(Collectors.toList());
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -16,6 +16,6 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // 유저의 루트 목록 조회
     List<Route> findRouteByUser(User user);
 
-    // 그룹의 루트 목록 조회
-    List<Route> findRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
+    // 그룹의 루트 개수 조회
+    int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 그룹 목록 조회, 그룹 구성원 조회
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 그룹 목록 조회 API
- 그룹 구성원 조회 API
- 기존 그룹 1건 조회 API에서 그룹 구성원 조회 메소드를 사용하도록 코드 수정

### 작업 후 기대 동작(스크린샷)

- 그룹 목록 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/de3b10a9-0af5-4e32-ad70-146e9186f17c)

- 그룹 구성원 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/429592b4-03af-49ed-8fbb-0eb1e9b6ff55)


### Issue Number 

close: #80 
