### PR TITLE
feat: Group 초대코드 생성 및 조회 API

### DIFF
--- a/gusto/build.gradle
+++ b/gusto/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 
 	// jsch 라이브러리, for ssh tunneling
 	implementation 'com.github.mwiede:jsch:0.2.16'

--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.group.controller;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
+import com.umc.gusto.domain.group.model.response.GetInvitationCodeResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.user.entity.User;
@@ -60,6 +61,16 @@ public class GroupController {
         User owner = authUser.getUser();
         groupService.deleteGroup(owner, groupId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * 초대 코드 조회
+     * [GET] /groups/{groupId}/invitationCode
+     */
+    @GetMapping("/{groupId}/invitationCode")
+    public ResponseEntity<GetInvitationCodeResponse> getInvitationCode(@PathVariable Long groupId){
+        GetInvitationCodeResponse getInvitationCode = groupService.getInvitationCode(groupId);
+        return ResponseEntity.status(HttpStatus.OK).body(getInvitationCode);
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
@@ -24,6 +24,6 @@ public class InvitationCode extends BaseTime {
     @JoinColumn(name = "groupId", nullable = false)
     private Group group;
 
-    @Column(columnDefinition = "VARCHAR(6)")
+    @Column(columnDefinition = "VARCHAR(12)")
     private String code;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetInvitationCodeResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetInvitationCodeResponse.java
@@ -1,0 +1,16 @@
+package com.umc.gusto.domain.group.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetInvitationCodeResponse {
+    Long invitationCodeId;
+    Long groupId;
+    String code;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
@@ -1,0 +1,7 @@
+package com.umc.gusto.domain.group.repository;
+
+import com.umc.gusto.domain.group.entity.InvitationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvitationCodeRepository extends JpaRepository<InvitationCode, Long> {
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
@@ -1,7 +1,11 @@
 package com.umc.gusto.domain.group.repository;
 
+import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.InvitationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface InvitationCodeRepository extends JpaRepository<InvitationCode, Long> {
+    Optional<InvitationCode> findInvitationCodeByGroup(Group group);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.group.service;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
+import com.umc.gusto.domain.group.model.response.GetInvitationCodeResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.user.entity.User;
 
@@ -18,4 +19,7 @@ public interface GroupService {
 
     // 그룹 삭제
     void deleteGroup(User owner, Long groupId);
+
+    // 그룹 초대 코드 조회
+    GetInvitationCodeResponse getInvitationCode(Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
+import com.umc.gusto.domain.group.model.response.GetInvitationCodeResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.group.repository.GroupMemberRepository;
 import com.umc.gusto.domain.group.repository.GroupRepository;
@@ -123,5 +124,18 @@ public class GroupServiceImpl implements GroupService{
         // 그룹 삭제
         group.updateStatus(BaseEntity.Status.INACTIVE);
         groupRepository.save(group);
+    }
+    @Transactional(readOnly = true)
+    public GetInvitationCodeResponse getInvitationCode(Long groupId){
+        Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
+        InvitationCode invitationCode = invitationCodeRepository.findInvitationCodeByGroup(group)
+                .orElseThrow(()->new GeneralException(Code.INVITATION_CODE_NOT_FOUND));
+
+        return GetInvitationCodeResponse.builder()
+                .invitationCodeId(invitationCode.getInvitationCodeId())
+                .groupId(invitationCode.getGroup().getGroupId())
+                .code(invitationCode.getCode())
+                .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.gusto.domain.group.service;
 
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.GroupMember;
+import com.umc.gusto.domain.group.entity.InvitationCode;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
 import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
@@ -9,6 +10,7 @@ import com.umc.gusto.domain.group.model.response.GetGroupResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.group.repository.GroupMemberRepository;
 import com.umc.gusto.domain.group.repository.GroupRepository;
+import com.umc.gusto.domain.group.repository.InvitationCodeRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import com.umc.gusto.global.exception.Code;
@@ -16,6 +18,7 @@ import com.umc.gusto.global.exception.GeneralException;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,8 +29,11 @@ import java.util.stream.Collectors;
 public class GroupServiceImpl implements GroupService{
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final InvitationCodeRepository invitationCodeRepository;
+    private static final int INVITE_CODE_LENGTH = 12;
 
     public void createGroup(User owner, PostGroupRequest postGroupRequest){
+        // 그룹
         Group group = Group.builder()
                 .groupName(postGroupRequest.getGroupName())
                 .groupScript(postGroupRequest.getGroupScript())
@@ -35,11 +41,21 @@ public class GroupServiceImpl implements GroupService{
                 .notice("멤버들에게 새로운 공지사항을 공유해보세요!")
                 .build();
         Group savedGroup = groupRepository.save(group);
+
+        // 그룹 멤버
         GroupMember ownerMember = GroupMember.builder()
                 .group(savedGroup)
                 .user(owner)
                 .build();
         groupMemberRepository.save(ownerMember);
+
+        // 초대 코드
+        String code = RandomStringUtils.randomAlphanumeric(INVITE_CODE_LENGTH);
+        InvitationCode invitationCode = InvitationCode.builder()
+                .group(group)
+                .code(code)
+                .build();
+        invitationCodeRepository.save(invitationCode);
     }
 
     @Transactional(readOnly = true)

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -33,6 +33,7 @@ public enum Code {
     FIND_FAIL_GROUP(HttpStatus.NOT_FOUND, 404401, "존재하지 않는 그룹입니다."),
     UNAUTHORIZED_DELETE_GROUP(HttpStatus.FORBIDDEN, 403402, "그룹을 삭제할 권한이 없습니다."),
     UNAUTHORIZED_MODIFY_GROUP_NAME(HttpStatus.FORBIDDEN, 403403, "그룹명을 수정할 권한이 없습니다."),
+    INVITATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, 404404,"그룹의 초대 코드를 찾을 수 없습니다."),
 
     //myCategory 관련 에러 +5
     MYCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 그룹 초대 코드 생성 & 조회
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
- 초대 코드: 대문자, 소문자, 숫자를 포함한 임의의 12자리 문자열
- 그룹 생성 시 한 그룹 당 영구 초대 코드 하나 발급
- 그룹 초대 코드 조회

### 작업 후 기대 동작(스크린샷)

- 그룹 초대 코드 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/5d30ad5a-42e1-4944-a8de-e1f5de343e48)


### Issue Number 

close: #86 
