### PR TITLE
refactor : 가게 상세 조회 시 리뷰 날짜별 분류 처리

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -21,10 +21,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
     @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC LIMIT 4")
     List<Review> findFirst4ByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.reviewId DESC")
+    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.visitedAt DESC, r.reviewId DESC")
     List<Review> findFirstReviewsByStore(Store store, Pageable pageable);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.reviewId < :reviewId ORDER BY r.reviewId DESC")
-    List<Review> findReviewsAfterIdByStore(Store store, Long reviewId, Pageable pageable);
+    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.visitedAt <= :visitedAt AND r.reviewId < :reviewId ORDER BY r.visitedAt DESC, r.reviewId DESC")
+    List<Review> findReviewsAfterIdByStore(Store store, LocalDate visitedAt, Long reviewId, Pageable pageable);
     boolean existsByReviewIdAndUser(Long reviewId, User user);
     Integer countByStoreAndUserNickname(Store store, String nickname);      // 방문횟수는 리뷰 공개여부과 상관 X
     Integer countByStoreAndUser(Store store, User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -44,12 +45,13 @@ public class StoreController {
     public ResponseEntity<GetStoreDetailResponse> getStoreDetail(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long storeId,
+            @RequestParam(name = "visitedAt", required = false) LocalDate visitedAt,
             @RequestParam(name = "reviewId", required = false) Long reviewId){
         User user = authUser.getUser();
         Pageable pageable = PageRequest.of(0, 3);
 
         // 상점 세부 정보 가져오기
-        GetStoreDetailResponse getStoreDetail = storeService.getStoreDetail(user, storeId, reviewId, pageable);
+        GetStoreDetailResponse getStoreDetail = storeService.getStoreDetail(user, storeId, visitedAt, reviewId, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(getStoreDetail);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -24,6 +24,9 @@ import java.util.List;
 public class StoreController {
     private final StoreService storeService;
 
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int DEFAULT_PAGE_SIZE = 3;
+
     /**
      * 가게 1건 조회
      * [GET] /stores/{storeId}
@@ -48,7 +51,7 @@ public class StoreController {
             @RequestParam(name = "visitedAt", required = false) LocalDate visitedAt,
             @RequestParam(name = "reviewId", required = false) Long reviewId){
         User user = authUser.getUser();
-        Pageable pageable = PageRequest.of(0, 3);
+        Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE);
 
         // 상점 세부 정보 가져오기
         GetStoreDetailResponse getStoreDetail = storeService.getStoreDetail(user, storeId, visitedAt, reviewId, pageable);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreDetailResponse.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Builder
 @Getter
@@ -18,6 +20,6 @@ public class GetStoreDetailResponse{
     String address;
     Boolean pin;        // 찜 여부
     List<String> reviewImg4;
-    List<GetReviewsResponse> reviews;
+    Map<LocalDate, List<GetReviewsResponse>> reviews;
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
@@ -6,12 +6,13 @@ import com.umc.gusto.domain.store.model.response.GetStoresInMapResponse;
 import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
 public interface StoreService {
 
     GetStoreResponse getStore(User user, Long storeId);
-    GetStoreDetailResponse getStoreDetail(User user, Long storeId, Long reviewId, Pageable pageable);
+    GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId, Pageable pageable);
     List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -21,6 +21,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +73,7 @@ public class StoreServiceImpl implements StoreService{
 
 
     @Transactional(readOnly = true)
-    public GetStoreDetailResponse getStoreDetail(User user, Long storeId, Long reviewId, Pageable pageable) {
+    public GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId, Pageable pageable) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
         Category category = storeRepository.findCategoryByStoreId(storeId)
@@ -88,31 +90,33 @@ public class StoreServiceImpl implements StoreService{
         int pageNumber = pageable.getPageNumber();
         List<Review> reviews;
 
-        if (reviewId != null) {
-            pageSize = PAGE_SIZE_FIRST;
-            reviews = reviewRepository.findReviewsAfterIdByStore(store, reviewId, PageRequest.of(pageNumber, pageSize));
-        } else {
+        if (reviewId != null && visitedAt != null) {
             pageSize = PAGE_SIZE;
+            reviews = reviewRepository.findReviewsAfterIdByStore(store, visitedAt, reviewId, PageRequest.of(pageNumber, pageSize));
+        } else {
+            pageSize = PAGE_SIZE_FIRST;
             reviews = reviewRepository.findFirstReviewsByStore(store, PageRequest.of(pageNumber, pageSize));
         }
 
-        List<GetReviewsResponse> getReviews = reviews.stream()
-                .map(review -> {
-                    User reviewer = review.getUser();
-                    return GetReviewsResponse.builder()
-                        .reviewId(review.getReviewId())
-                        .visitedAt(review.getVisitedAt())
-                        .profileImage(reviewer.getProfileImage())
-                        .nickname(reviewer.getNickname())
-                        .liked(review.getLiked())
-                        .comment(review.getComment())
-                        .img1(review.getImg1())
-                        .img2(review.getImg2())
-                        .img3(review.getImg3())
-                        .img4(review.getImg4())
-                        .build();
-                })
-                .toList();
+        Map<LocalDate, List<GetReviewsResponse>> reviewsByVisitedAt = new LinkedHashMap<>();
+
+        reviews.forEach(review -> {
+            LocalDate visitedAtDate = review.getVisitedAt();
+            GetReviewsResponse reviewsResponse = GetReviewsResponse.builder()
+                    .reviewId(review.getReviewId())
+                    .visitedAt(review.getVisitedAt())
+                    .profileImage(review.getUser().getProfileImage())
+                    .nickname(review.getUser().getNickname())
+                    .liked(review.getLiked())
+                    .comment(review.getComment())
+                    .img1(review.getImg1())
+                    .img2(review.getImg2())
+                    .img3(review.getImg3())
+                    .img4(review.getImg4())
+                    .build();
+
+            reviewsByVisitedAt.computeIfAbsent(visitedAtDate, k -> new ArrayList<>()).add(reviewsResponse);
+        });
 
         boolean isPinned = pinRepository.existsByUserAndStoreStoreId(user, storeId);
 
@@ -123,7 +127,7 @@ public class StoreServiceImpl implements StoreService{
                 .address(store.getAddress())
                 .reviewImg4(reviewImg)
                 .pin(isPinned)
-                .reviews(getReviews)
+                .reviews(reviewsByVisitedAt)
                 .build();
     }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : refactor : 가게 상세 조회 시 리뷰 날짜별 sort(분류) 처리
- [ ] 버그 수정 :
- [x] 리펙토링 : 페이징 페이지 수 상수 사용 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 가게 조회를 통한 리뷰 조회 시 날짜별로 sort되어 보여지기 때문에 날짜별로 조회되도록 return 값 수정이 있습니다.

### 작업 내역

- Map을 사용해 visitedAt를 기준으로 분류해서 조회
- 최신 방문일자를 기준으로 sort를 하니 reviewId만 받아 페이징 할때 혼동이 있어, visitedAt까지 쿼리로 받아 페이징 처리해씁니다.
- reviewId가 null 일때 3개의 리뷰를 조회해야하는데, null이 아닐 때 3개를 조회해와 상수 사용 변경이 있습니다.

### 작업 후 기대 동작(스크린샷)

- 가게 조회 시 리뷰 날짜별 조회
<img width="716" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/d467fd0e-1197-42f1-aed9-ae0e0f7ab2d3">

### Issue Number 

close: #119

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
* 변경된 `@Query`을 봐주시면 될거 같습니다.