### PR TITLE
refactor: @Valid 에러를 체크하지 못하는 부분 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/exception/ExceptionResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/ExceptionResponse.java
@@ -1,10 +1,14 @@
 package com.umc.gusto.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record ExceptionResponse<T>(
         int errorCode,
-        String message
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T result
 ) {
-    public static <T> ExceptionResponse<T> from(Code code){
-        return new ExceptionResponse<>(code.getCode(), code.getMessage());
+    public static <T> ExceptionResponse<T> from(Code code, T result){
+        return new ExceptionResponse<>(code.getCode(), code.getMessage(), result);
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/handler/GlobalExceptionHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/handler/GlobalExceptionHandler.java
@@ -7,13 +7,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @RestControllerAdvice(annotations = {RestController.class})
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -27,32 +33,54 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternalConstraint(e, Code.valueOf(errorMessage), request);
     }
 
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,Code.INVALID_REQUEST,request,errors);
+    }
+
+
     @org.springframework.web.bind.annotation.ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
-        return handleExceptionInternalFalse(e, Code.INTERNAL_SEVER_ERROR, request);
+        return handleExceptionInternalFalse(e, Code.INTERNAL_SEVER_ERROR, request, e.getMessage());
     }
 
     @ExceptionHandler(value = GeneralException.class)
-    public ResponseEntity customException(GeneralException generalException, HttpServletRequest request) {
+    public ResponseEntity<Object> customException(GeneralException generalException, HttpServletRequest request) {
         Code errorCode = generalException.getCode();
         return handleExceptionInternal(generalException,errorCode,null, request);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(Exception e, Code errorCode, HttpHeaders httpHeader,HttpServletRequest request) {
 
-        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode, null);
         WebRequest webRequest = new ServletWebRequest(request);
         return super.handleExceptionInternal(e, body, httpHeader, errorCode.getHttpStatus(), webRequest);
     }
 
-    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, Code errorCode, WebRequest request) {
-        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, Code errorCode, WebRequest request, String errorPoint) {
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode, errorPoint);
+        return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorCode.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, Code errorCode, WebRequest request, Map<String, String> errorArgs) {
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode, errorArgs);
         return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorCode.getHttpStatus(), request);
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, Code errorCode, WebRequest request) {
-        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode);
+        ExceptionResponse<Object> body = ExceptionResponse.from(errorCode, null);
         return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorCode.getHttpStatus(), request);
     }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
@Valid로 유효성 검사한 부분이 예외핸들러에서 잡지 못해서 @Valid에 적어둔 메시지가 넘어가지 않았습니다. 

### 작업 내역
잘못된 요청이라는 메세지와 함께 @Valid에서 더 자세히 적어준 메세지도 넘기도록 했습니다.
```
{
    "errorCode": 400,
    "message": "잘못된 요청입니다.",
    "result": {
        "storeId": "storeId는 null일 수 없습니다."
    }
}
```
### Issue Number 
#19 

