### PR TITLE
refactor/rename :그룹 내 식당 정보 조회 시 식당 대표 이미지, 추가한 유저 프로필 전달

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GroupListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GroupListResponse.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GroupListResponse {
     private String storeName;
+    private Long storeId;
     private String storeProfileImg;
     private String userProfileImg;
     private String address;

--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GroupListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GroupListResponse.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GroupListResponse {
     private String storeName;
-    private String profileImg;
+    private String storeProfileImg;
+    private String userProfileImg;
     private String address;
     private Long groupListId;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -290,7 +290,8 @@ public class GroupServiceImpl implements GroupService{
             return GroupListResponse.builder()
                     .groupListId(gl.getGroupListId())
                     .storeName(gl.getStore().getStoreName())
-                    .profileImg(reviewImg)
+                    .storeProfileImg(reviewImg)
+                    .userProfileImg(gl.getUser().getProfileImage())
                     .address(gl.getStore().getAddress())
                     .build();
         }).collect(Collectors.toList());

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -289,6 +289,7 @@ public class GroupServiceImpl implements GroupService{
             String reviewImg = reviewRepository.findTopReviewImageByStoreId(gl.getStore().getStoreId()).get(0);
             return GroupListResponse.builder()
                     .groupListId(gl.getGroupListId())
+                    .storeId(gl.getStore().getStoreId())
                     .storeName(gl.getStore().getStoreName())
                     .storeProfileImg(reviewImg)
                     .userProfileImg(gl.getUser().getProfileImage())

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -2,7 +2,7 @@ package com.umc.gusto.domain.route.controller;
 
 import com.umc.gusto.domain.route.model.request.RouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteResponse;
-import com.umc.gusto.domain.route.service.RouteServiceImpl;
+import com.umc.gusto.domain.route.service.RouteService;
 import com.umc.gusto.global.auth.model.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +18,11 @@ import java.util.List;
 @RequestMapping("routes")
 @RequiredArgsConstructor
 public class RouteController {
-    private final RouteServiceImpl routeService;
+    private final RouteService routeService;
 
     // 루트 생성
     @PostMapping("")
-    public ResponseEntity createRoute(
+    public ResponseEntity<?> createRoute(
             @RequestBody @Valid RouteRequest.createRouteDto request,
             @AuthenticationPrincipal AuthUser authUSer)
     {
@@ -32,12 +32,12 @@ public class RouteController {
 
     // 루트 삭제
     @DeleteMapping("/{routeId}")
-    public ResponseEntity deleteRoute(
+    public ResponseEntity<?> deleteRoute(
             @PathVariable Long routeId,
             @AuthenticationPrincipal AuthUser authUSer)
     {
         routeService.deleteRoute(routeId,authUSer.getUser());
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.ok().build();
     }
 
     // 내 루트 조회

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -1,7 +1,7 @@
 package com.umc.gusto.domain.route.controller;
 
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
-import com.umc.gusto.domain.route.service.RouteListServiceImpl;
+import com.umc.gusto.domain.route.service.RouteListService;
 import com.umc.gusto.global.auth.model.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +19,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RouteListController {
 
-    private final RouteListServiceImpl routeListService;
+    private final RouteListService routeListService;
 
     // 루르리스트 항목 삭제
     @DeleteMapping("/{routeListId}")
-    public ResponseEntity deleteRouteLis(
+    public ResponseEntity<?> deleteRouteLis(
             @PathVariable Long routeListId,
             @AuthenticationPrincipal AuthUser authUSer
     ){

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
@@ -22,8 +22,6 @@ public class RouteListResponse {
         private Float latitude;
         private Long routeListId;
         private Integer ordinal;
-
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         private Long storeId;
         @JsonInclude(JsonInclude.Include.NON_NULL)
         private String storeName;

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -5,14 +5,19 @@ import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route,Long> {
 
-    // 동일한 이름의 루트가 있는지 확인
-    Boolean existsByRouteNameAndStatus(String routeName, BaseEntity.Status status);
+    // 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
+    Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
+
+//    Boolean existsByRouteNameAndStatus(String routeName, BaseEntity.Status status);
 
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -17,20 +17,16 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
     Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
 
-//    Boolean existsByRouteNameAndStatus(String routeName, BaseEntity.Status status);
-
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);
 
     // 그룹X, ACTIVE
-    @Query("SELECT r FROM Route r WHERE r.routeId = ?1 AND r.status = ?2 AND r.group.groupId IS NULL")
-    Optional<Route> findRouteByRouteIdAndStatusAndGroup(Long routeId, BaseEntity.Status status);
+    @Query("SELECT r FROM Route r WHERE r.routeId = :routeId AND r.status = :status AND r.group.groupId IS NULL")
+    Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
 
     // 유저의 루트 목록 조회 , 그룹X
-    List<Route> findRouteByUserAndStatus(User user, BaseEntity.Status status);
-
-    // 그룹의 루트 목록 조회
-    List<Route> findRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
+    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ")
+    List<Route> findRouteByUserAndStatus(@Param("user") User user, @Param("status") BaseEntity.Status status);
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -22,7 +22,11 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);
 
-    // 유저의 루트 목록 조회
+    // 그룹X, ACTIVE
+    @Query("SELECT r FROM Route r WHERE r.routeId = ?1 AND r.status = ?2 AND r.group.groupId IS NULL")
+    Optional<Route> findRouteByRouteIdAndStatusAndGroup(Long routeId, BaseEntity.Status status);
+
+    // 유저의 루트 목록 조회 , 그룹X
     List<Route> findRouteByUserAndStatus(User user, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -20,11 +20,11 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);
 
-    // 그룹X, ACTIVE
+    // 루트 단일 조회 그룹X, ACTIVE
     @Query("SELECT r FROM Route r WHERE r.routeId = :routeId AND r.status = :status AND r.group.groupId IS NULL")
     Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
 
-    // 유저의 루트 목록 조회 , 그룹X
+    // 유저의 루트 목록 조회 , 그룹X, ACTIVE
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ")
     List<Route> findRouteByUserAndStatus(@Param("user") User user, @Param("status") BaseEntity.Status status);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -60,6 +60,7 @@ public class RouteListServiceImpl implements RouteListService{
                         .latitude(rL.getStore().getLatitude())
                         .routeListId(rL.getRouteListId())
                         .ordinal(rL.getOrdinal())
+                        .storeId(rL.getStore().getStoreId())
                         .build()
         ).toList();
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -35,7 +35,7 @@ public class RouteListServiceImpl implements RouteListService{
             RouteList routeList = RouteList.builder()
                     .route(route)
                     .store(storeRepository.findById(dto.getStoreId())
-                            .orElseThrow(() -> new NotFoundException(Code.STORE_NOT_FOUND)))
+                            .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND)))
                     .ordinal(dto.getOrdinal())
                     .build();
             routeListRepository.save(routeList);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -67,7 +67,6 @@ public class RouteServiceImpl implements RouteService{
 
     @Override
     public List<RouteResponse.RouteResponseDto> getRoute(User user) {
-        //TODO: group 루트 제외하기
         List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);
         return routes.stream().map(
                         Route -> RouteResponse.RouteResponseDto.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -50,13 +50,16 @@ public class RouteServiceImpl implements RouteService{
 
     @Transactional
     @Override
-    public void deleteRoute(Long routeId,User user) {
-        Route route = routeRepository.findById(routeId).orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
+    public void deleteRoute(Long routeId, User user) {
+        // 그룹X, ACTIVE 한정
+        Route route = routeRepository.findRouteByRouteIdAndStatusAndGroup(routeId,BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
 
         // 루트를 생성한 유저만 삭제
-        if(!route.getUser().equals(user)){
+        if(!route.getUser().getNickname().equals(user.getNickname())){
             throw new GeneralException(Code.USER_NO_PERMISSION_FOR_ROUTE);
         }
+
         //루트 삭제 : soft delete // TODO:DB 최종 삭제 주기 체크
         route.updateStatus(BaseEntity.Status.INACTIVE);
 
@@ -64,6 +67,7 @@ public class RouteServiceImpl implements RouteService{
 
     @Override
     public List<RouteResponse.RouteResponseDto> getRoute(User user) {
+        //TODO: group 루트 제외하기
         List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);
         return routes.stream().map(
                         Route -> RouteResponse.RouteResponseDto.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
@@ -15,7 +15,7 @@ public class City {
     @Column(nullable = false, updatable = false)
     private Long cityId;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(3)")
+    @Column(nullable = false, columnDefinition = "VARCHAR(7)")
     private String cityCode;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 : 그룹 내 식당 정보 조회 시 식당 대표이미지, 추가자 이미지 전달
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 기존 식당 대표 이미지가 단순 profileImage로 되어 있어 변수 네이밍 측면에서 정보 전달에 혼동을 유발했음
- 그룹 내 식당을 추가한 유저의 프로필 이미지 정보를 추가함
- 식당 상세 조회 편리성을 위해 식당 식별값을 응답 시 추가함

### 특이사항 ###
Bug로 인한 기존 PR이 존재함으로 이전 develop으로 롤백 시 버그 해결에 문제가 발생할 가능성을 고려해 Bug 해결 후,
#123 해당 pr 이후 반영할 예정임. 

### Issue Number 

close: #124 

