### PR TITLE
feat: 프로필 정보 조회 API

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.user.controller;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
+import com.umc.gusto.domain.user.model.response.ProfileResponse;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
 import com.umc.gusto.domain.user.service.UserService;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
@@ -111,6 +112,20 @@ public class UserController {
 
         return ResponseEntity.ok()
                 .build();
+    }
+
+    /**
+     * 프로필 정보 조회
+     * [GET] /users/my-info
+     * @param -
+     * @return -
+     */
+    @GetMapping("/my-info")
+    public ResponseEntity getProfile(@AuthenticationPrincipal AuthUser authUser) {
+        ProfileResponse profileResponse = userService.getProfile(authUser.getUser());
+
+        return ResponseEntity.ok()
+                .body(profileResponse);
     }
 
     /**

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -6,7 +6,7 @@ import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
 import com.umc.gusto.domain.user.service.UserService;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
-import com.umc.gusto.domain.user.model.response.ProfileResponse;
+import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
 import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.global.auth.model.AuthUser;
 import com.umc.gusto.global.auth.model.Tokens;
@@ -85,15 +85,15 @@ public class UserController {
      * @return ProfileRes
      */
     @GetMapping("/{nickname}/profile")
-    public ResponseEntity<ProfileResponse> retrieveProfile(@AuthenticationPrincipal AuthUser authUser,
-                                                           @PathVariable("nickname") String nickname) {
+    public ResponseEntity<FeedProfileResponse> retrieveProfile(@AuthenticationPrincipal AuthUser authUser,
+                                                               @PathVariable("nickname") String nickname) {
         User user = null;
 
         if(authUser != null) {
             user = authUser.getUser();
         }
 
-        ProfileResponse profileRes = userService.getProfile(user, nickname);
+        FeedProfileResponse profileRes = userService.getProfile(user, nickname);
 
         return ResponseEntity.ok()
                 .body(profileRes);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -104,6 +104,10 @@ public class User extends BaseTime {
         this.publishCategory = status;
     }
 
+    public void updatePublishRoute(PublishStatus status) {
+        this.publishRoute = status;
+    }
+
     public void updateFollower(long follower) {
         this.follower = follower;
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/request/PublishingInfoRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/request/PublishingInfoRequest.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.user.model.request;
 public class PublishingInfoRequest {
     private boolean publishReview;
     private boolean publishPin;
+    private boolean publishRoute;
 
     public boolean getPublishReview() {
         return this.publishReview;
@@ -11,4 +12,6 @@ public class PublishingInfoRequest {
     public boolean getPublishPin() {
         return this.publishPin;
     }
+
+    public boolean getPublishRoute() { return this.publishRoute; }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FeedProfileResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FeedProfileResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @Getter
-public class ProfileResponse {
+public class FeedProfileResponse {
     private String nickname;
     private int review;
     private int pin;

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/ProfileResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/ProfileResponse.java
@@ -1,0 +1,15 @@
+package com.umc.gusto.domain.user.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class ProfileResponse {
+    String profileImg;
+    String nickname;
+    String age;
+    String gender;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/PublishingInfoResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/PublishingInfoResponse.java
@@ -10,4 +10,5 @@ import lombok.Getter;
 public class PublishingInfoResponse {
     private boolean publishReview;
     private boolean publishPin;
+    private boolean publishRoute;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -4,9 +4,8 @@ import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
-import com.umc.gusto.domain.user.model.response.ProfileResponse;
+import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
-import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.global.auth.model.Tokens;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +27,7 @@ public interface UserService {
     String generateRandomNickname();
 
     // 먹스또 프로필 조회
-    ProfileResponse getProfile(User user, String nickname);
+    FeedProfileResponse getProfile(User user, String nickname);
 
     // 닉네임 갱신
     void updateNickname(User user, String nickname);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
 import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
+import com.umc.gusto.domain.user.model.response.ProfileResponse;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
 import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.global.auth.model.Tokens;
@@ -31,6 +32,9 @@ public interface UserService {
 
     // 닉네임 갱신
     void updateNickname(User user, String nickname);
+
+    // 프로필 정보 리턴
+    ProfileResponse getProfile(User user);
 
     // 프로필 정보 갱신
     void updateProfile(User user, MultipartFile profileImg, UpdateProfileRequest request);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -206,6 +206,7 @@ public class UserServiceImpl implements UserService{
         return PublishingInfoResponse.builder()
                 .publishReview(user.getPublishReview() == PublishStatus.PUBLIC)
                 .publishPin(user.getPublishCategory() == PublishStatus.PUBLIC)
+                .publishRoute(user.getPublishRoute() == PublishStatus.PUBLIC)
                 .build();
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
 import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
+import com.umc.gusto.domain.user.model.response.ProfileResponse;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
 import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.domain.user.repository.FollowRepository;
@@ -177,6 +178,16 @@ public class UserServiceImpl implements UserService{
         user.updateNickname(nickname);
 
         userRepository.save(user);
+    }
+
+    @Override
+    public ProfileResponse getProfile(User user) {
+        return ProfileResponse.builder()
+                .profileImg(user.getProfileImage())
+                .nickname(user.getNickname())
+                .age(user.getAge().toString())
+                .gender(user.getGender().toString())
+                .build();
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -214,9 +214,11 @@ public class UserServiceImpl implements UserService{
     public void updatePublishingInfo(User user, PublishingInfoRequest request) {
         PublishStatus reviewStatus = (request.getPublishReview()) ?PublishStatus.PUBLIC : PublishStatus.PRIVATE;
         PublishStatus pinStatus = (request.getPublishPin()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
+        PublishStatus routeStatus = (request.getPublishRoute()) ? PublishStatus.PUBLIC : PublishStatus.PRIVATE;
 
         user.updatePublishReview(reviewStatus);
         user.updatePublishPin(pinStatus);
+        user.updatePublishRoute(routeStatus);
 
         userRepository.save(user);
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -7,7 +7,7 @@ import com.umc.gusto.domain.user.model.NicknameBucket;
 import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
-import com.umc.gusto.domain.user.model.response.ProfileResponse;
+import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
 import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
 import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.domain.user.repository.FollowRepository;
@@ -149,7 +149,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public ProfileResponse getProfile(User user, String nickname) {
+    public FeedProfileResponse getProfile(User user, String nickname) {
         User target = userRepository.findByNicknameAndMemberStatusIs(nickname, User.MemberStatus.ACTIVE)
                 .orElseThrow(() -> new GeneralException(Code.DONT_EXIST_USER));
 
@@ -159,7 +159,7 @@ public class UserServiceImpl implements UserService{
             followRepository.findByFollowerAndFollowing(user, target).ifPresent(a -> followed.set(true));
         }
 
-        return ProfileResponse.builder()
+        return FeedProfileResponse.builder()
                 .nickname(target.getNickname())
                 .review(target.getReviewCnt())
                 .pin(target.getPinCnt())


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 프로필 정보 조회 API
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 아래 화면에 대한 API 입니다.
  ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/ca1f9f42-38f0-46bf-b8be-950a9e9f0d90)


### 작업 후 기대 동작(스크린샷)

- 화면에 대한 값을 출력합니다. (나이, 성별 정보 역시 포함하여 전송됩니다.)
  <img width="727" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/90233522/26977a61-9875-4050-a56a-818bdaf0f5f8">


### Issue Number 

close: #128 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
Spring Security 로직 상 프로필 정보를 return하기 위해 User 정보 조회를 추가로 거치지 않습니다.
따라서 Controller에서도 충분히 정보 처리가 가능하지만, Service단에서 DTO로의 변환이 이루어집니다.
저희 코드 전반적으로 DTO를 위한 Converter class를 따로 사용하지 않아 별도의 business logic이 존재하지 않음에도
Service단에서 처리를 하였는데, 다른 의견이 있으신지 궁금합니다!

