### PR TITLE
feat: access token 재발급 API

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
@@ -2,8 +2,12 @@ package com.umc.gusto.global.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.gusto.domain.user.model.response.FirstLogInResponse;
+import com.umc.gusto.global.auth.model.Tokens;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -13,6 +17,7 @@ import java.io.IOException;
 @RequestMapping("/auth")
 public class AuthController {
     private final ObjectMapper objectMapper;
+    private final JwtService jwtService;
 
     @GetMapping("/result/member")
     public void returnLoginResult(HttpServletResponse response,
@@ -38,5 +43,19 @@ public class AuthController {
 
         response.setHeader("temp-token", tempToken);
         response.getWriter().write(objectMapper.writeValueAsString(firstLogInResponse));
+    }
+
+    @PostMapping("/reissue-token")
+    public ResponseEntity reissueToken(@RequestHeader("X-AUTH-TOKEN") String accessToken,
+                                       @RequestHeader("refresh-Token") String refreshToken) {
+        Tokens tokens = jwtService.reissueToken(accessToken, refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-AUTH-TOKEN", tokens.getAccessToken());
+        headers.add("refresh-token", tokens.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .headers(headers)
+                .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
@@ -97,7 +97,13 @@ public class JwtService implements InitializingBean {
 
     @Transactional
     public Tokens reissueToken(String accessToken, String refreshToken) {
-        String accessUuid = (String) getClaims(accessToken).get(UUID);
+        String accessUuid = null;
+
+        try {
+            accessUuid = (String) getClaims(accessToken).get(UUID);
+        } catch (ExpiredJwtException e) {
+            accessUuid = String.valueOf(e.getClaims().get(UUID));
+        }
 
         try {
             getClaims(refreshToken);

--- a/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
@@ -2,6 +2,8 @@ package com.umc.gusto.global.auth;
 
 import com.umc.gusto.global.auth.model.Tokens;
 import com.umc.gusto.global.config.secret.JwtConfig;
+import com.umc.gusto.global.exception.Code;
+import com.umc.gusto.global.exception.GeneralException;
 import com.umc.gusto.global.util.RedisService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -13,6 +15,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -90,5 +93,29 @@ public class JwtService implements InitializingBean {
         redisService.setValuesWithTimeout(tokens.getRefreshToken(), userUUID, REFRESH_TOKEN_VALID_TIME);
 
         return tokens;
+    }
+
+    @Transactional
+    public Tokens reissueToken(String accessToken, String refreshToken) {
+        String accessUuid = (String) getClaims(accessToken).get(UUID);
+
+        try {
+            getClaims(refreshToken);
+
+            String value = redisService.getValues(refreshToken)
+                    .orElseThrow(() -> new GeneralException(Code.INVALID_REFRESH_TOKEN));
+
+            if(!value.equals(accessUuid)) {
+                throw new GeneralException(Code.INVALID_REFRESH_TOKEN);
+            }
+
+            // 기존 refresh token 삭제 후 재생성
+            redisService.deleteValues(refreshToken);
+            Tokens newTokens = createAndSaveTokens(value);
+
+            return newTokens;
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(Code.EXPIRED_REFRESH_TOKEN);
+        }
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -59,7 +59,9 @@ public enum Code {
 
     // token 관련 에러 +6
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 401601, "유효하지 않은 토큰입니다."),
-
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 401603, "refresh-token이 유효하지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.FORBIDDEN, 403601, "X-AUTH-TOKEN이 만료되었습니다. 토큰 재발급을 실행해주세요."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, 403602, "refresh-token이 만료되었습니다. 재로그인이 필요합니다"),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 

--- a/gusto/src/main/java/com/umc/gusto/global/util/RedisService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/util/RedisService.java
@@ -14,7 +14,7 @@ public class RedisService {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void setValuesWithTimeout(String key, String value, long timeout) {
-        redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MICROSECONDS);
+        redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : Access Token 재발급 API
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- Access-Token (X-AUTH-TOKEN) 만료 시 Access-Token을 재발급 받을 수 있는 API입니다.
- 만료된 X-AUTH-TOKEN과 refresh-token을 헤더로 모두 요구합니다.
  - refresh-token 역시 만료되었다면 재로그인을 해야 합니다.

### Issue Number 

close: #63