### PR TITLE
chore: city, town 엔티티의 code field 길이 변경

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/City.java
@@ -15,7 +15,7 @@ public class City {
     @Column(nullable = false, updatable = false)
     private Long cityId;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(3)")
+    @Column(nullable = false, columnDefinition = "VARCHAR(5)")
     private String cityCode;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Town.java
@@ -15,7 +15,7 @@ public class Town {
     @Column(nullable = false, updatable = false)
     private Long townId;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(3)")
+    @Column(nullable = false, columnDefinition = "VARCHAR(8)")
     private String townCode;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : city, town 엔티티 code 필드 길이 변경

### 변경사항 및 이유

- 참조 데이터 변경으로 인한 조치

### PR 특이 사항

- 해당 PR merge 이후 minnie schema에서 곧바로 데이터베이스를 매핑하지 못할 수 있습니다.
- 해당 문제는 0.1.0-alpha.4 버전 배포시 db의 schema를 직접 변경한 이후 조치될 예정입니다.