### PR TITLE
refactor: 그룹 목록 조회 시 그룹장 여부 반환

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetGroupsResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetGroupsResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class GetGroupsResponse {
     Long groupId;
     String groupName;
+    Boolean isOwner;
     Integer numMembers;
     Integer numRestaurants;
     Integer numRoutes;

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -197,6 +197,7 @@ public class GroupServiceImpl implements GroupService{
                     return GetGroupsResponse.builder()
                             .groupId(group.getGroupId())
                             .groupName(group.getGroupName())
+                            .isOwner(user.getUserId().equals(group.getOwner().getUserId()))
                             .numMembers(numMembers)
                             .numRestaurants(numRestaurants)
                             .numRoutes(numRoutes)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 그룹 목록 조회 시 그룹장 여부 반환
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 그룹 목록 조회 시 사용자가 그룹의 소유자인지 여부를 확인하여 해당 정보를 반환하도록 리펙토링
- 이유: 프론트엔드 요구(그룹 리스트 페이지에서 그룹장에게만 그룹 삭제 버튼이 뜸)

### 작업 내역

- getUserGroups 메소드에서 그룹의 소유자 여부를 확인하여 GetGroupsResponse에 반영하는 코드를 추가

### 작업 후 기대 동작(스크린샷)

- 그룹 목록 조회 시 사용자가 그룹의 소유자인 경우에는 true를, 아닌 경우에는 false를 반환
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/5fc007af-e2ec-4412-b5c6-c05a392cfa13)

### Issue Number 

close: #135 