### PR TITLE
refactor : 내 카테고리 조회 시 myCategoryScript 추가 조회 / fix : 카테고리 수정 시 중복이름 버그 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/CreateMyCategoryRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/request/CreateMyCategoryRequest.java
@@ -12,7 +12,7 @@ public class CreateMyCategoryRequest {
     @Size(max=20, message = "카테고리 설명은 20자를 초과할 수 없습니다.")
     String myCategoryScript;
     Integer myCategoryIcon;
-    PublishStatus publishCategory;
+//    PublishStatus publishCategory;            // 데모데이 이후
     BaseEntity.Status status = BaseEntity.Status.ACTIVE;
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/MyCategoryResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/MyCategoryResponse.java
@@ -10,6 +10,7 @@ import lombok.*;
 public class MyCategoryResponse{
     Long myCategoryId;
     String myCategoryName;
+    String myCategoryScript;
     Integer myCategoryIcon;
     PublishStatus publishCategory;
     Integer pinCnt;

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -47,6 +47,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 .map(myCategory -> MyCategoryResponse.builder()
                         .myCategoryId(myCategory.getMyCategoryId())
                         .myCategoryName(myCategory.getMyCategoryName())
+                        .myCategoryScript(myCategory.getMyCategoryScript())
                         .myCategoryIcon(myCategory.getMyCategoryIcon())
                         .publishCategory(user.getPublishCategory())
                         .pinCnt(myCategory.getPinList().size())            // pin 개수 받아오기로 변경
@@ -66,6 +67,7 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                     return MyCategoryResponse.builder()
                             .myCategoryId(myCategory.getMyCategoryId())
                             .myCategoryName(myCategory.getMyCategoryName())
+                            .myCategoryScript(myCategory.getMyCategoryScript())
                             .myCategoryIcon(myCategory.getMyCategoryIcon())
                             .publishCategory(user.getPublishCategory())
                             .pinCnt(pinList.size())            // pin 개수 받아오기로 변경

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -151,27 +151,28 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 .orElseThrow(() -> new GeneralException(Code.MYCATEGORY_NOT_FOUND));
 
         // 중복 이름 체크
-        if (updateMyCategory.getMyCategoryName() != null && updateMyCategory.getMyCategoryName().equals(existingMyCategory.getMyCategoryName())) {
+        if (updateMyCategory.getMyCategoryName() != null && !updateMyCategory.getMyCategoryName().equals(existingMyCategory.getMyCategoryName())) {
             myCategoryRepository.findByMyCategoryNameAndUser(updateMyCategory.getMyCategoryName(), user)
                     .ifPresent(existingCategory -> {
                 throw new GeneralException(Code.MYCATEGORY_DUPLICATE_NAME);
             });
         }
+        // 변경하려는 필드만 업데이트
+        if (updateMyCategory.getMyCategoryName() != null) {
+            existingMyCategory.updateMyCategoryName(updateMyCategory.getMyCategoryName());
+        }
 
-            // 변경하려는 필드만 업데이트
-            if (updateMyCategory.getMyCategoryName() != null) {
-                existingMyCategory.updateMyCategoryName(updateMyCategory.getMyCategoryName());
-            }
+        if (updateMyCategory.getMyCategoryIcon() != null) {
+            existingMyCategory.updateMyCategoryIcon(updateMyCategory.getMyCategoryIcon());
+        }
 
-            if (updateMyCategory.getMyCategoryIcon() != null) {
-                existingMyCategory.updateMyCategoryIcon(updateMyCategory.getMyCategoryIcon());
-            }
+        if (updateMyCategory.getMyCategoryScript() != null) {
+            existingMyCategory.updateMyCategoryScript(updateMyCategory.getMyCategoryScript());
+        }
 
-            if (updateMyCategory.getMyCategoryScript() != null) {
-                existingMyCategory.updateMyCategoryScript(updateMyCategory.getMyCategoryScript());
-            }
+        myCategoryRepository.save(existingMyCategory);
 
-            myCategoryRepository.save(existingMyCategory);
+
     }
 
     @Transactional


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 카테고리 수정 시 이름 변경이 없는데도 중복에러 뜨는 부분 수정
- [x] 리펙토링 : 내 카테고리 조회 시 myCategoryScript 추가 조회 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 내 카테고리 수정 시 카테고리 설명 조회가 필요해 myCategoryScript를 추가했습니다.
- 내 카테고리 수정 시 myCategoryName를 변경하지 않더라도 기본 값에 대해 중복으로 인식하는 오류가 있어 수정했습니다.

### 작업 후 기대 동작(스크린샷)

- 카테고리 전체 조회 & 위치 기반 내 카테고리 전체 조회
<img width="227" alt="스크린샷 2024-02-14 212434" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/3c0d1abe-c275-4021-82dd-cfc87351cfc1">

- 카테고리 수정(카테고리의 이름이 아닌 다른 필드를 수정 시 카테고리 이름을 중복으로 인식 못하게 변경)
<img width="428" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/c126e277-a5a7-40ca-9580-b15469eb1e51">


### Issue Number 

close: #139
