### PR TITLE
feat: 프로필 정보 조회 시 프로필 이미지 return / refactor: default img 관련 처리

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/ProfileResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/ProfileResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class ProfileResponse {
     private String nickname;
+    private String profileImg;
     private int review;
     private int pin;
     private long follower;

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -52,7 +52,7 @@ public class UserServiceImpl implements UserService{
     private static final int FOLLOW_LIST_PAGE = 30;
 
 
-    @Value("${default.img.url.profile}")
+    @Value("${default.img.url}")
     private String DEFAULT_PROFILE_IMG;
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -161,6 +161,7 @@ public class UserServiceImpl implements UserService{
 
         return ProfileResponse.builder()
                 .nickname(target.getNickname())
+                .profileImg(target.getProfileImage())
                 .review(target.getReviewCnt())
                 .pin(target.getPinCnt())
                 .follower(target.getFollower())

--- a/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class OAuthService extends DefaultOAuth2UserService {
     private final SocialRepository socialRepository;
     private final UserService userService;
-    @Value("${default.img.url.profile}")
+    @Value("${default.img.url}")
     private String DEFAULT_PROFILE_IMG;
 
     // 유저 불러오기 - 해당 유저의 security context가 저장됨


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 프로필 정보 조회 시 프로필 이미지를 함께 return
- [ ] 버그 수정 :
- [x] 리펙토링 : default 이미지 경로 변경에 따라 key를 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 프로필 이미지 return : 프로필 이미지 내역이 프로필 정보 조회 시 누락되어 있어 수정하였습니다
- default 이미지 properties 값 수정
  - 디폴트 프로필 이미지와 디폴트 리뷰 이미지를 동일하게 사용함에 따라 `default.img.url.profile`였던 properties key 값을 `default.img.url`으로 변경하여 공통 리소스로 관리하도록 하였습니다.

### PR 특이 사항

- 해당 PR merge 이후 application.properties 파일 교체가 필요합니다. 노션 문서 확인 후 교체 부탁드립니다.
