### PR TITLE
refactor: 리뷰 생성 시 이미지 값이 null이면 디폴트 이미지로 저장하도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -21,6 +21,7 @@ import com.umc.gusto.global.exception.customException.NotFoundException;
 import com.umc.gusto.global.util.S3Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,6 +30,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService{
+    @Value("${default.img.url}")
+    private String DEFAULT_IMG;
     private final ReviewRepository reviewRepository;
     private final StoreRepository storeRepository;
     private final HashTagRepository hashTagRepository;
@@ -63,6 +66,8 @@ public class ReviewServiceImpl implements ReviewService{
         //s3에 이미지 저장
         if(images!=null){
             updateImages(images, review);
+        }else{ //이미지가 null인 경우 디폴트 이미지로 저장
+            review.updateImg1(DEFAULT_IMG);
         }
 
         //리뷰와 해시태그 연결


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
기존에는 리뷰 생성 시 이미지 값이 null이면 이미지를 아예 저장하지 않았음

### 작업 내역
리뷰 생성 시 이미지 값이 null이면 디폴트 이미지로 저장하도록 수정

### Issue Number 
#37 