### PR TITLE
feat: 먹스또 프로필 - 본인 조회 시, 닉네임이 아닌 키워드를 사용하도록 대체

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -151,8 +151,14 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public FeedProfileResponse getProfile(User user, String nickname) {
-        User target = userRepository.findByNicknameAndMemberStatusIs(nickname, User.MemberStatus.ACTIVE)
-                .orElseThrow(() -> new GeneralException(Code.DONT_EXIST_USER));
+        User target;
+
+        if(nickname.equals("my")) {
+            target = user;
+        } else {
+            target = userRepository.findByNicknameAndMemberStatusIs(nickname, User.MemberStatus.ACTIVE)
+                    .orElseThrow(() -> new GeneralException(Code.DONT_EXIST_USER));
+        }
 
         AtomicBoolean followed = new AtomicBoolean(false);
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 자신의 먹스또 프로필 조회 시 닉네임 대신 `my` 키워드 사용
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 현재 API 설계 상 로그인 시 token 외 추가적인 정보를 반환하고 있지 않아 본인의 닉네임을 조회하는 데 어려움이 있습니다.
- 로그인 시 닉네임(식별정보)를 반환하게 되면 token을 사용하는 주된 이유인 `stateless`에 위배가 됩니다.
- 따라서 자기 자신의 정보 조회 시, 본인의 닉네임 대신 예약된 키워드인 `my`를 사용하도록 하였습니다.
- `my` 키워드를 예약 키워드로 사용하기 위해, `my`의 닉네임 생성이 제한됩니다.

### PR 특이 사항

- 빠른 배포를 위해 merge 처리 먼저 하도록 하겠습니다. 차후 review, 혹은 확인했다는 이모지 달아주시면 될 것 같습니다.