### PR TITLE
fix: 해시태그 id가 아닌 엔티티 주소 값이 넘어가는 상황 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
@@ -6,15 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 @Getter
 public class ReviewDetailResponse {
     Long storeId;
     String storeName;
-    String nickName;
     LocalDate visitedAt;
-    //TODO: img고려
+    List<String> images;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String menuName;
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,9 +36,8 @@ public class ReviewDetailResponse {
         return ReviewDetailResponse.builder()
                 .storeId(review.getStore().getStoreId())
                 .storeName(review.getStore().getStoreName())
-                .nickName(review.getUser().getNickname())
                 .visitedAt(review.getVisitedAt())
-//                    .img() TODO: img 처리하기
+                .images(review.getImageList())
                 .menuName(review.getMenuName())
                 .hashTags(hashTags)
                 .taste(review.getTaste())

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -145,7 +145,9 @@ public class ReviewServiceImpl implements ReviewService{
         }
 
         StringBuilder hashTags = new StringBuilder();
-        review.getTaggingSet().stream().map(Tagging::getHashTag).forEach(o-> hashTags.append(o).append(","));
+        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(o-> hashTags.append(o).append(","));
+        //마지막 문자 , 제거
+        hashTags.deleteCharAt(hashTags.length()-1);
         return ReviewDetailResponse.of(review, hashTags.toString());
     }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 리뷰 1건 조회 API
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
리뷰의 해시태그가 ID가 아닌 해시태그 엔티티 주소 값이 응답으로 넘어가고 있었습니다. ID를 반환하도록 수정하였습니다. 

### Issue Number 
#37
