### PR TITLE
feat: 먹스또 프로필 조회 시 팔로잉 수 반환

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -57,6 +57,9 @@ public class User extends BaseTime {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long follower;
 
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long following;
+
     @Column(nullable = false, columnDefinition = "int default 0")
     private Integer pinCnt;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/User.java
@@ -114,4 +114,8 @@ public class User extends BaseTime {
     public void updateFollower(long follower) {
         this.follower = follower;
     }
+
+    public void updateFollowing(long following) {
+        this.following = following;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FeedProfileResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/FeedProfileResponse.java
@@ -11,7 +11,7 @@ public class FeedProfileResponse {
     private String nickname;
     private String profileImg;
     private int review;
-    private int pin;
+    private long following;
     private long follower;
     private boolean followed;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -267,7 +267,9 @@ public class UserServiceImpl implements UserService{
 
         // target의 팔로워 수 1 증가
         target.updateFollower(target.getFollower() + 1);
+        user.updateFollowing(user.getFollowing() + 1);
         userRepository.save(target);
+        userRepository.save(user);
     }
 
     @Override
@@ -283,7 +285,9 @@ public class UserServiceImpl implements UserService{
 
         // target의 팔로워 수 1 감소
         target.updateFollower(target.getFollower() - 1);
+        user.updateFollowing(user.getFollowing() - 1);
         userRepository.save(target);
+        userRepository.save(user);
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -170,7 +170,7 @@ public class UserServiceImpl implements UserService{
                 .nickname(target.getNickname())
                 .profileImg(target.getProfileImage())
                 .review(target.getReviewCnt())
-                .pin(target.getPinCnt())
+                .following(target.getFollowing())
                 .follower(target.getFollower())
                 .followed(followed.get())
                 .build();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 먹스또 프로필 조회 시 팔로잉 수를 반환 합니다
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 먹스또 프로필 화면이 변경됨에 따라 설계를 변경하였습니다.
  - 기존 화면
    ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/b8678d21-d162-4b85-af75-6adf2a96d6c4)
  - 변경 화면
    <img width="623" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/90233522/df13ed1f-04e5-4b4a-b7d8-6bed8fa41750">
  - following 수 관리를 위해 **user entity에 following 필드가 추가되었습니다.**

### 작업 내역

- follow / unfollow 시 following 필드가 갱신됩니다.

### PR 특이 사항

- **해당 PR merge 이후 user 엔티티 변경이 필요합니다.**
