### PR TITLE
feat: 초대 코드로 그룹 참여 및 중복 가입 예외 처리 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -107,12 +107,12 @@ public class GroupController {
 
     /**
      * 그룹 참여
-     * [POST] /groups/{groupId}/join
+     * [POST] /groups/join
      */
-    @PostMapping("/{groupId}/join")
-    public ResponseEntity<?> joinGroup(@AuthenticationPrincipal AuthUser authUser, @PathVariable Long groupId, @RequestBody JoinGroupRequest joinGroupRequest){
+    @PostMapping("/join")
+    public ResponseEntity<?> joinGroup(@AuthenticationPrincipal AuthUser authUser, @RequestBody JoinGroupRequest joinGroupRequest){
         User user = authUser.getUser();
-        groupService.joinGroup(user, groupId, joinGroupRequest);
+        groupService.joinGroup(user, joinGroupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
@@ -1,9 +1,10 @@
 package com.umc.gusto.domain.group.repository;
 
 import com.umc.gusto.domain.group.entity.Group;
-import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +13,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findGroupByGroupId(Long groupId);
     Optional<Group> findGroupByGroupIdAndStatus(Long groupId, BaseEntity.Status status);
     List<Group> findGroupsByGroupIdInAndStatus(List<Long> groupIds, BaseEntity.Status status);
+    @Query("SELECT ic.group FROM InvitationCode ic WHERE ic.code = :code AND ic.group.status = :status")
+    Optional<Group> findGroupByCodeAndStatus(@Param("code") String code, @Param("status") BaseEntity.Status status);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -45,7 +45,7 @@ public interface GroupService {
     TransferOwnershipResponse transferOwnership(User owner, Long groupId, TransferOwnershipRequest transferOwnershipRequest);
 
     // 그룹 참여
-    void joinGroup(User user, Long groupId, JoinGroupRequest joinGroupRequest);
+    void joinGroup(User user, JoinGroupRequest joinGroupRequest);
 
     // 그룹 탈퇴
     void leaveGroup(User user, Long groupId);

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -143,6 +143,12 @@ public class GroupServiceImpl implements GroupService{
         Group group = groupRepository.findGroupByCodeAndStatus(joinGroupRequest.getCode(), BaseEntity.Status.ACTIVE)
                 .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
 
+        // 이미 그룹에 참여한 유저인지 확인
+        boolean isMember = groupMemberRepository.existsGroupMemberByGroupAndUser(group, user);
+        if (isMember) {
+            throw new GeneralException(Code.ALREADY_JOINED_GROUP);
+        }
+
         // 그룹 참여
         User joinUser = userRepository.findById(user.getUserId())
                 .orElseThrow(()->new GeneralException(Code.DONT_EXIST_USER));

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -139,26 +139,20 @@ public class GroupServiceImpl implements GroupService{
         group.updateStatus(BaseEntity.Status.INACTIVE);
     }
 
-    public void joinGroup(User user, Long groupId, JoinGroupRequest joinGroupRequest){
-        Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
+    public void joinGroup(User user, JoinGroupRequest joinGroupRequest){
+        Group group = groupRepository.findGroupByCodeAndStatus(joinGroupRequest.getCode(), BaseEntity.Status.ACTIVE)
                 .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
-        String invitationCode = invitationCodeRepository.findCodeByGroup(group);
 
-        // 초대 코드 확인
-        if(joinGroupRequest.getCode().equals(invitationCode)){
-            // 그룹 참여
-            User joinUser = userRepository.findById(user.getUserId())
-                    .orElseThrow(()->new GeneralException(Code.DONT_EXIST_USER));
+        // 그룹 참여
+        User joinUser = userRepository.findById(user.getUserId())
+                .orElseThrow(()->new GeneralException(Code.DONT_EXIST_USER));
 
-            GroupMember groupMember = GroupMember.builder()
-                    .group(group)
-                    .user(joinUser)
-                    .build();
+        GroupMember groupMember = GroupMember.builder()
+                .group(group)
+                .user(joinUser)
+                .build();
 
-            groupMemberRepository.save(groupMember);
-        }else{
-            throw new GeneralException(Code.INVALID_INVITATION_CODE);
-        }
+        groupMemberRepository.save(groupMember);
     }
 
     public void leaveGroup(User user, Long groupId){

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -51,6 +51,7 @@ public enum Code {
     NO_TRANSFER_PERMISSION(HttpStatus.FORBIDDEN, 403407, "그룹 소유자만이 그룹 소유권을 이전할 수 있습니다."),
     USER_NO_PERMISSION_FOR_GROUP(HttpStatus.FORBIDDEN,403408,"해당 유저는 그룹 구성원이 아닙니다."),
     GROUPLIST_NOT_FROUND(HttpStatus.NOT_FOUND,403409,"존재하지 않는 그룹 내 상점입니다."),
+    ALREADY_JOINED_GROUP(HttpStatus.BAD_REQUEST, 400410, "이미 해당 그룹에 참여한 유저입니다."),
   
     //myCategory 관련 에러 +5
     MYCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 초대 코드로 그룹 참여 및 중복 가입 예외 처리 추가
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 그룹 참여 시 사용자가 groupId를 알 수 없으므로 초대 코드만으로 가입할 수 있도록 수정
- 그룹 참여 시 이미 참여한 사용자에 한하여 예외처리 필요

### 작업 내역

- 그룹에 가입할 때 그룹 ID 필요없이 초대 코드만을 사용하도록 수정
- 이미 그룹에 가입한 유저가 다시 가입하려고 할 때 예외 처리 추가

### 작업 후 기대 동작(스크린샷)

- 초대 코드로만 그룹 참여 (최초 가입)
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/8e94a6a6-d82b-478e-8819-cab07cca2a19)

- 초대 코드로만 그룹 참여 (이미 가입한 경우 예외처리)
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/cbce30f3-0e71-4de9-8fa6-e75ca8a92b43)


### Issue Number 

close: #155 