### PR TITLE
refactor : 위치 여부에 상관 없이 API 통일 / 내 카테고리 조회 시 토큰으로 처리 

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
@@ -22,7 +22,7 @@ public class MyCategoryController {
 
     /**
      * 카테고리 전체 조회
-     * [GET] /myCategories/{nickname}
+     * [GET] /myCategories?nickname={nickname}&townName={townName}
      */
     @GetMapping
     public ResponseEntity<List<MyCategoryResponse>> allMyCategory(
@@ -34,20 +34,6 @@ public class MyCategoryController {
 
         return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
     }
-
-    /**
-     * 위치 기반 내 카테고리 전체 조회
-     * [GET] /myCategories?townName={townName}
-     */
-//    @GetMapping
-//    public ResponseEntity<List<MyCategoryResponse>> allMyCategoryWithLocation(
-//            @AuthenticationPrincipal AuthUser authUser,
-//            @RequestParam(name = "townName") String townName) {
-//            User user = authUser.getUser();
-//            List<MyCategoryResponse> myCategoryList = myCategoryService.getAllMyCategoryWithLocation(user, townName);
-//
-//            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
-//    }
 
     /**
      * 카테고리 별 가게 목록 조회
@@ -65,21 +51,6 @@ public class MyCategoryController {
 
             return ResponseEntity.status(HttpStatus.OK).body(myStoreList);
     }
-
-    /**
-     * 위치 기반 내 카테고리 별 가게 목록 조회
-     * [GET] /myCategories/pins?myCategoryId={mycategoryId}&townName={townName}
-     */
-//    @GetMapping("/pins")
-//    public ResponseEntity<List<PinByMyCategoryResponse>> allPinByCategoryWithLocation(
-//            @AuthenticationPrincipal AuthUser authUser,
-//            @RequestParam(name = "myCategoryId") Long myCategoryId,
-//            @RequestParam(name = "townName") String townName) {
-//            User user = authUser.getUser();
-//            List<PinByMyCategoryResponse> myCategoryList = myCategoryService.getAllPinByMyCategoryWithLocation(user, myCategoryId,townName);
-//
-//            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
-//    }
 
     /**
      * 내 카테고리 생성

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
@@ -24,12 +24,13 @@ public class MyCategoryController {
      * 카테고리 전체 조회
      * [GET] /myCategories/{nickname}
      */
-    @GetMapping("/{nickname}")
+    @GetMapping
     public ResponseEntity<List<MyCategoryResponse>> allMyCategory(
             @AuthenticationPrincipal AuthUser authUser,
-            @PathVariable String nickname) {
+            @RequestParam(name = "nickname", required = false) String nickname,
+            @RequestParam(name = "townName", required = false) String townName) {
         User user = authUser.getUser();
-        List<MyCategoryResponse> myCategoryList = myCategoryService.getAllMyCategory(user, nickname);
+        List<MyCategoryResponse> myCategoryList = myCategoryService.getAllMyCategory(user, nickname, townName);
 
         return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
     }
@@ -38,27 +39,29 @@ public class MyCategoryController {
      * 위치 기반 내 카테고리 전체 조회
      * [GET] /myCategories?townName={townName}
      */
-    @GetMapping
-    public ResponseEntity<List<MyCategoryResponse>> allMyCategoryWithLocation(
-            @AuthenticationPrincipal AuthUser authUser,
-            @RequestParam(name = "townName") String townName) {
-            User user = authUser.getUser();
-            List<MyCategoryResponse> myCategoryList = myCategoryService.getAllMyCategoryWithLocation(user, townName);
-
-            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
-    }
+//    @GetMapping
+//    public ResponseEntity<List<MyCategoryResponse>> allMyCategoryWithLocation(
+//            @AuthenticationPrincipal AuthUser authUser,
+//            @RequestParam(name = "townName") String townName) {
+//            User user = authUser.getUser();
+//            List<MyCategoryResponse> myCategoryList = myCategoryService.getAllMyCategoryWithLocation(user, townName);
+//
+//            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
+//    }
 
     /**
      * 카테고리 별 가게 목록 조회
-     * [GET] /myCategories/pins/{nickname}?myCategoryId={myCategoryId}
+     * [GET] /myCategories/pins?nickname={nickname}&myCategoryId={myCategoryId}&townName={townName}
      */
-    @GetMapping("/pins/{nickname}")
+    @GetMapping("/pins")             // 나의 찜을 조회 할 시 nickname 값을 받지 않고, nickname이 조회될 경우 townName을 받지 않음
     public ResponseEntity<List<PinByMyCategoryResponse>> allPinByMyCategory(
             @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(name = "nickname", required = false) String nickname,
             @RequestParam(name = "myCategoryId") Long myCategoryId,
-            @PathVariable String nickname) {
+            @RequestParam(name = "townName", required = false) String townName
+            ) {
             User user = authUser.getUser();
-            List<PinByMyCategoryResponse> myStoreList = myCategoryService.getAllPinByMyCategory(user, nickname, myCategoryId);
+            List<PinByMyCategoryResponse> myStoreList = myCategoryService.getAllPinByMyCategory(user, nickname, myCategoryId, townName);
 
             return ResponseEntity.status(HttpStatus.OK).body(myStoreList);
     }
@@ -67,16 +70,16 @@ public class MyCategoryController {
      * 위치 기반 내 카테고리 별 가게 목록 조회
      * [GET] /myCategories/pins?myCategoryId={mycategoryId}&townName={townName}
      */
-    @GetMapping("/pins")
-    public ResponseEntity<List<PinByMyCategoryResponse>> allPinByCategoryWithLocation(
-            @AuthenticationPrincipal AuthUser authUser,
-            @RequestParam(name = "myCategoryId") Long myCategoryId,
-            @RequestParam(name = "townName") String townName) {
-            User user = authUser.getUser();
-            List<PinByMyCategoryResponse> myCategoryList = myCategoryService.getAllPinByMyCategoryWithLocation(user, myCategoryId,townName);
-
-            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
-    }
+//    @GetMapping("/pins")
+//    public ResponseEntity<List<PinByMyCategoryResponse>> allPinByCategoryWithLocation(
+//            @AuthenticationPrincipal AuthUser authUser,
+//            @RequestParam(name = "myCategoryId") Long myCategoryId,
+//            @RequestParam(name = "townName") String townName) {
+//            User user = authUser.getUser();
+//            List<PinByMyCategoryResponse> myCategoryList = myCategoryService.getAllPinByMyCategoryWithLocation(user, myCategoryId,townName);
+//
+//            return ResponseEntity.status(HttpStatus.OK).body(myCategoryList);
+//    }
 
     /**
      * 내 카테고리 생성

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/controller/MyCategoryController.java
@@ -54,9 +54,11 @@ public class MyCategoryController {
      */
     @GetMapping("/pins/{nickname}")
     public ResponseEntity<List<PinByMyCategoryResponse>> allPinByMyCategory(
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(name = "myCategoryId") Long myCategoryId,
             @PathVariable String nickname) {
-            List<PinByMyCategoryResponse> myStoreList = myCategoryService.getAllPinByMyCategory(nickname, myCategoryId);
+            User user = authUser.getUser();
+            List<PinByMyCategoryResponse> myStoreList = myCategoryService.getAllPinByMyCategory(user, nickname, myCategoryId);
 
             return ResponseEntity.status(HttpStatus.OK).body(myStoreList);
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
@@ -36,10 +36,10 @@ public class MyCategory extends BaseEntity{
     @Column(length = 20)
     private String myCategoryScript;
 
-    @Builder.Default
-    @Enumerated(EnumType.STRING)
-    @Column(name = "publishCategory",nullable = false, length = 10)
-    private PublishStatus publishCategory = PublishStatus.PUBLIC;
+//    @Builder.Default
+//    @Enumerated(EnumType.STRING)
+//    @Column(name = "publishCategory",nullable = false, length = 10)
+//    private PublishStatus publishCategory = PublishStatus.PUBLIC;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
@@ -9,15 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MyCategoryRepository extends JpaRepository<MyCategory, Long> {
-
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.nickname = :nickname")
-    List<MyCategory> findByUserNickname(String nickname);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user.nickname = :nickname")
-    List<MyCategory> findByUserNicknameAndPublishCategory(String nickname);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId")
-    Optional<MyCategory> findByMyCategoryIdAndUserNickname(String nickname, Long myCategoryId);
-    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user = :user")
-    List<MyCategory> findByStatusAndPublishCategoryAndUser(User user);
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user = :user")
+    List<MyCategory> findByUserNicknameAndPublishCategory(User user);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.myCategoryName = :myCategoryName AND m.user = :user")
     Optional<MyCategory> findByMyCategoryNameAndUser(String myCategoryName, User user);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.myCategoryId = :myCategoryId AND m.user = :user")

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
@@ -9,7 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MyCategoryRepository extends JpaRepository<MyCategory, Long> {
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId")
+    Optional<MyCategory> findByMyCategoryPublicIdAndUserNickname(String nickname, Long myCategoryId);
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.nickname = :nickname AND m.myCategoryId = :myCategoryId")
+    Optional<MyCategory> findByMyCategoryIdAndUserNickname(String nickname, Long myCategoryId);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user.publishCategory = 'PUBLIC' AND m.user = :user")
+    List<MyCategory> findByUserNicknameAndPublishCategoryPublic(User user);
+    @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.user = :user")
     List<MyCategory> findByUserNicknameAndPublishCategory(User user);
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.myCategoryName = :myCategoryName AND m.user = :user")
     Optional<MyCategory> findByMyCategoryNameAndUser(String myCategoryName, User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -13,11 +13,15 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @Query("SELECT p FROM Pin p " +
             "JOIN p.store s " +
             "JOIN s.town t " +
-            "WHERE p.myCategory = :myCategory AND t.townName = :townName " +
-            "AND p.user.publishCategory = 'PUBLIC'" +
+            "WHERE p.myCategory = :myCategory " +
+            "AND t.townName = :townName " +
             "ORDER BY p.pinId DESC")
-    List<Pin> findAllByUserAndMyCategoryOrderByPinIdDesc(MyCategory myCategory, String townName);
-
+    List<Pin> findPinsByMyCategoryAndTownNameAndPinIdDESC(MyCategory myCategory, String townName);
+    @Query("SELECT p FROM Pin p " +
+            "JOIN p.store s " +
+            "WHERE p.myCategory = :myCategory " +
+            "ORDER BY p.pinId DESC")
+    List<Pin> findPinsByMyCategoryAndPinIdDESC(MyCategory myCategory);
     @Query("SELECT p FROM Pin p " +
             "JOIN p.store s " +
             "JOIN s.town t " +
@@ -25,17 +29,8 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
             "WHERE p.user = :user " +
             "AND p.myCategory.myCategoryId = :myCategoryId " +
             "AND t.townName = :townName " +
-            "AND u.publishCategory = 'PUBLIC' " +
             "ORDER BY p.pinId DESC")
     List<Pin> findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(User user, Long myCategoryId, String townName);
-    @Query("SELECT p FROM Pin p " +
-            "JOIN p.store s " +
-            "JOIN p.user u " +
-            "WHERE p.user = :user " +
-            "AND p.myCategory.myCategoryId = :myCategoryId " +
-            "AND u.publishCategory = 'PUBLIC' " +
-            "ORDER BY p.pinId DESC")
-    List<Pin> findPinsByUserAndMyCategoryIdAndPinIdDESC(User user, Long myCategoryId);
     Optional<Pin> findByUserAndPinId(User user, Long pinId);
     boolean existsByUserAndStoreStoreId(User user, Long storeId);       // 존재 여부
     @Query("SELECT p.store.storeId FROM Pin p WHERE p.user = :user AND p.myCategory.myCategoryId = :myCategoryId AND p.user.publishCategory = 'PUBLIC'")

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -10,13 +10,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PinRepository extends JpaRepository<Pin, Long> {
-    @Query("SELECT p FROM Pin p ORDER BY p.pinId DESC")
-    List<Pin> findByMyCategoryOrderByPinIdDesc(MyCategory myCategory);
-
     @Query("SELECT p FROM Pin p " +
             "JOIN p.store s " +
             "JOIN s.town t " +
             "WHERE p.myCategory = :myCategory AND t.townName = :townName " +
+            "AND p.user.publishCategory = 'PUBLIC'" +
             "ORDER BY p.pinId DESC")
     List<Pin> findAllByUserAndMyCategoryOrderByPinIdDesc(MyCategory myCategory, String townName);
 
@@ -27,11 +25,20 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
             "WHERE p.user = :user " +
             "AND p.myCategory.myCategoryId = :myCategoryId " +
             "AND t.townName = :townName " +
+            "AND u.publishCategory = 'PUBLIC' " +
             "ORDER BY p.pinId DESC")
     List<Pin> findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(User user, Long myCategoryId, String townName);
+    @Query("SELECT p FROM Pin p " +
+            "JOIN p.store s " +
+            "JOIN p.user u " +
+            "WHERE p.user = :user " +
+            "AND p.myCategory.myCategoryId = :myCategoryId " +
+            "AND u.publishCategory = 'PUBLIC' " +
+            "ORDER BY p.pinId DESC")
+    List<Pin> findPinsByUserAndMyCategoryIdAndPinIdDESC(User user, Long myCategoryId);
     Optional<Pin> findByUserAndPinId(User user, Long pinId);
     boolean existsByUserAndStoreStoreId(User user, Long storeId);       // 존재 여부
-    @Query("SELECT p.store.storeId FROM Pin p WHERE p.user = :user AND p.myCategory.myCategoryId = :myCategoryId")
+    @Query("SELECT p.store.storeId FROM Pin p WHERE p.user = :user AND p.myCategory.myCategoryId = :myCategoryId AND p.user.publishCategory = 'PUBLIC'")
     List<Long> findStoreIdsByUserAndMyCategoryId(User user, Long myCategoryId);
     @Query("SELECT p.store.storeId FROM Pin p WHERE p.user = :user")
     List<Long> findStoreIdsByUser(User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
@@ -10,12 +10,12 @@ import java.util.List;
 
 public interface MyCategoryService {
 
-    List<MyCategoryResponse> getAllMyCategory(User user, String nickname);
-    List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName);
+    List<MyCategoryResponse> getAllMyCategory(User user, String nickname, String townName);
+//    List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName);
 
-    List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId);
+    List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId, String townName);
 
-    List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName);
+//    List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName);
 
     void createMyCategory(User user, CreateMyCategoryRequest request);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
@@ -13,7 +13,7 @@ public interface MyCategoryService {
     List<MyCategoryResponse> getAllMyCategory(User user, String nickname);
     List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName);
 
-    List<PinByMyCategoryResponse> getAllPinByMyCategory(String nickname, Long myCategoryId);
+    List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId);
 
     List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -65,26 +64,6 @@ public class MyCategoryServiceImpl implements MyCategoryService {
 
     }
 
-//    @Transactional(readOnly = true)
-//    public List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName) {
-//        List<MyCategory> myCategoryList = myCategoryRepository.findByStatusAndPublishCategoryAndUser(user);                                      // 특정 townName인 storesList
-//
-//        return myCategoryList.stream()
-//                .map(myCategory -> {
-//                    List<Pin> pinList = pinRepository.findAllByUserAndMyCategoryOrderByPinIdDesc(myCategory, townName);     // 먼저 카테고리로 구분
-//
-//                    return MyCategoryResponse.builder()
-//                            .myCategoryId(myCategory.getMyCategoryId())
-//                            .myCategoryName(myCategory.getMyCategoryName())
-//                            .myCategoryScript(myCategory.getMyCategoryScript())
-//                            .myCategoryIcon(myCategory.getMyCategoryIcon())
-//                            .publishCategory(user.getPublishCategory())
-//                            .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
-//                            .build();
-//                })
-//                .collect(Collectors.toList());
-//    }
-
     @Transactional(readOnly = true)
     public List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId, String townName) {
         List<Pin> pinList;
@@ -122,33 +101,6 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 })
                 .collect(Collectors.toList());
     }
-
-//    @Transactional(readOnly = true)
-//    public List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName) {
-//        List<Pin> pinList = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
-//
-//        return getPinByMyCategoryResponses(user, pinList);
-//    }
-//
-//    private List<PinByMyCategoryResponse> getPinByMyCategoryResponses(User user, List<Pin> pinList) {
-//        return pinList.stream()                                     // townName을 기준으로 보일 수 있는 store가 포함된 pin만 보이기
-//                .map(pin -> {
-//                    Store store = pin.getStore();
-//                    Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);       // 가장 좋아요가 많은 review
-//                    String reviewImg = topReviewOptional.map(Review::getImg1).orElse(null);                               // 가장 좋아요가 많은 review 이미지
-//                    Integer reviewCnt = reviewRepository.countByStoreAndUserNickname(store, user.getNickname());                        // 내가 작성한 리뷰의 개수 == 방문 횟수
-//
-//                    return  PinByMyCategoryResponse.builder()
-//                            .pinId(pin.getPinId())
-//                            .storeId(store.getStoreId())
-//                            .storeName(store.getStoreName())
-//                            .address(store.getAddress())
-//                            .reviewImg(reviewImg)
-//                            .reviewCnt(reviewCnt)
-//                            .build();
-//                })
-//                .collect(Collectors.toList());
-//    }
 
     @Transactional
     public void createMyCategory(User user, CreateMyCategoryRequest createMyCategory) {

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -40,10 +40,9 @@ public class MyCategoryServiceImpl implements MyCategoryService {
         if (nickname != null) {
             if (nickname.equals(user.getNickname())) {
                 throw new GeneralException(Code.USER_NOT_FOUND_SELF);
-            } else {
-                user = userRepository.findByNickname(nickname)
-                        .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
             }
+            user = userRepository.findByNickname(nickname)
+                    .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
         }
         User finalUser = user;
         myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(user);   // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
@@ -70,10 +69,9 @@ public class MyCategoryServiceImpl implements MyCategoryService {
         if (nickname != null) {
             if (nickname.equals(user.getNickname())) {
                 throw new GeneralException(Code.USER_NOT_FOUND_SELF);
-            } else {
-                user = userRepository.findByNickname(nickname)
-                        .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
             }
+            user = userRepository.findByNickname(nickname)
+                    .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
         }
 
         if (townName == null) {

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -35,37 +35,19 @@ public class MyCategoryServiceImpl implements MyCategoryService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public List<MyCategoryResponse> getAllMyCategory(User user, String nickname) {
+    public List<MyCategoryResponse> getAllMyCategory(User user, String nickname, String townName) {
 
         List<MyCategory> myCategoryList;
-        if (nickname.equals("my")) {
-            myCategoryList = myCategoryRepository.findByUserNickname(user.getNickname());
-        } else if (nickname.equals(user.getNickname())) {
-            throw new GeneralException(Code.USER_FOUND_SELF);
-        } else {
-            user = userRepository.findByNickname(nickname)
-                    .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
-            myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(nickname);   // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
+        if (nickname != null) {
+            if (nickname.equals(user.getNickname())) {
+                throw new GeneralException(Code.USER_NOT_FOUND_SELF);
+            } else {
+                user = userRepository.findByNickname(nickname)
+                        .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
+            }
         }
-
         User finalUser = user;
-        return myCategoryList.stream()
-                .map(myCategory -> MyCategoryResponse.builder()
-                        .myCategoryId(myCategory.getMyCategoryId())
-                        .myCategoryName(myCategory.getMyCategoryName())
-                        .myCategoryScript(myCategory.getMyCategoryScript())
-                        .myCategoryIcon(myCategory.getMyCategoryIcon())
-                        .publishCategory(finalUser.getPublishCategory())
-                        .pinCnt(myCategory.getPinList().size())            // pin 개수 받아오기로 변경
-                        .build())
-                .collect(Collectors.toList());
-
-    }
-
-    @Transactional(readOnly = true)
-    public List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName) {
-        List<MyCategory> myCategoryList = myCategoryRepository.findByStatusAndPublishCategoryAndUser(user);                                      // 특정 townName인 storesList
-
+        myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(user);   // 받아온 nickname과 User의 nickname 값이 다른 경우(쿼리문 사용)
         return myCategoryList.stream()
                 .map(myCategory -> {
                     List<Pin> pinList = pinRepository.findAllByUserAndMyCategoryOrderByPinIdDesc(myCategory, townName);     // 먼저 카테고리로 구분
@@ -75,48 +57,59 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                             .myCategoryName(myCategory.getMyCategoryName())
                             .myCategoryScript(myCategory.getMyCategoryScript())
                             .myCategoryIcon(myCategory.getMyCategoryIcon())
-                            .publishCategory(user.getPublishCategory())
+                            .publishCategory(finalUser.getPublishCategory())
                             .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
                             .build();
                 })
                 .collect(Collectors.toList());
+
     }
 
+//    @Transactional(readOnly = true)
+//    public List<MyCategoryResponse> getAllMyCategoryWithLocation(User user, String townName) {
+//        List<MyCategory> myCategoryList = myCategoryRepository.findByStatusAndPublishCategoryAndUser(user);                                      // 특정 townName인 storesList
+//
+//        return myCategoryList.stream()
+//                .map(myCategory -> {
+//                    List<Pin> pinList = pinRepository.findAllByUserAndMyCategoryOrderByPinIdDesc(myCategory, townName);     // 먼저 카테고리로 구분
+//
+//                    return MyCategoryResponse.builder()
+//                            .myCategoryId(myCategory.getMyCategoryId())
+//                            .myCategoryName(myCategory.getMyCategoryName())
+//                            .myCategoryScript(myCategory.getMyCategoryScript())
+//                            .myCategoryIcon(myCategory.getMyCategoryIcon())
+//                            .publishCategory(user.getPublishCategory())
+//                            .pinCnt(pinList.size())            // pin 개수 받아오기로 변경
+//                            .build();
+//                })
+//                .collect(Collectors.toList());
+//    }
+
     @Transactional(readOnly = true)
-    public List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId) {
-        Optional<MyCategory> existingMyCategory;
-        if (nickname.equals("my")) {
-            existingMyCategory = myCategoryRepository.findByMyCategoryIdAndUserNickname(user.getNickname(), myCategoryId);
-        } else if (nickname.equals(user.getNickname())) {
-            throw new GeneralException(Code.USER_FOUND_SELF);
-        } else {
-            user = userRepository.findByNickname(nickname)
-                    .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
-            existingMyCategory = myCategoryRepository.findByMyCategoryIdAndUserNickname(nickname, myCategoryId);
+    public List<PinByMyCategoryResponse> getAllPinByMyCategory(User user, String nickname, Long myCategoryId, String townName) {
+        List<Pin> pinList;
+        if (nickname != null) {
+            if (nickname.equals(user.getNickname())) {
+                throw new GeneralException(Code.USER_NOT_FOUND_SELF);
+            } else {
+                user = userRepository.findByNickname(nickname)
+                        .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
+            }
         }
 
-        // 카테고리 별 가게 목록이 비어있으면 pinList도 비어 있음
-        List<Pin> pinList = existingMyCategory.map(pinRepository::findByMyCategoryOrderByPinIdDesc)
-                .orElse(Collections.emptyList());
+        if (townName == null) {
+            pinList = pinRepository.findPinsByUserAndMyCategoryIdAndPinIdDESC(user, myCategoryId);
+        } else {
+            pinList = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
+        }
 
         User finalUser = user;
-        return getPinByMyCategoryResponses(finalUser, pinList);
-    }
-
-    @Transactional(readOnly = true)
-    public List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName) {
-        List<Pin> pinList = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
-
-        return getPinByMyCategoryResponses(user, pinList);
-    }
-
-    private List<PinByMyCategoryResponse> getPinByMyCategoryResponses(User user, List<Pin> pinList) {
         return pinList.stream()                                     // townName을 기준으로 보일 수 있는 store가 포함된 pin만 보이기
                 .map(pin -> {
                     Store store = pin.getStore();
                     Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);       // 가장 좋아요가 많은 review
                     String reviewImg = topReviewOptional.map(Review::getImg1).orElse(null);                               // 가장 좋아요가 많은 review 이미지
-                    Integer reviewCnt = reviewRepository.countByStoreAndUserNickname(store, user.getNickname());                        // 내가 작성한 리뷰의 개수 == 방문 횟수
+                    Integer reviewCnt = reviewRepository.countByStoreAndUserNickname(store, finalUser.getNickname());                        // 내가 작성한 리뷰의 개수 == 방문 횟수
 
                     return  PinByMyCategoryResponse.builder()
                             .pinId(pin.getPinId())
@@ -129,6 +122,33 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 })
                 .collect(Collectors.toList());
     }
+
+//    @Transactional(readOnly = true)
+//    public List<PinByMyCategoryResponse> getAllPinByMyCategoryWithLocation(User user, Long myCategoryId, String townName) {
+//        List<Pin> pinList = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
+//
+//        return getPinByMyCategoryResponses(user, pinList);
+//    }
+//
+//    private List<PinByMyCategoryResponse> getPinByMyCategoryResponses(User user, List<Pin> pinList) {
+//        return pinList.stream()                                     // townName을 기준으로 보일 수 있는 store가 포함된 pin만 보이기
+//                .map(pin -> {
+//                    Store store = pin.getStore();
+//                    Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);       // 가장 좋아요가 많은 review
+//                    String reviewImg = topReviewOptional.map(Review::getImg1).orElse(null);                               // 가장 좋아요가 많은 review 이미지
+//                    Integer reviewCnt = reviewRepository.countByStoreAndUserNickname(store, user.getNickname());                        // 내가 작성한 리뷰의 개수 == 방문 횟수
+//
+//                    return  PinByMyCategoryResponse.builder()
+//                            .pinId(pin.getPinId())
+//                            .storeId(store.getStoreId())
+//                            .storeName(store.getStoreName())
+//                            .address(store.getAddress())
+//                            .reviewImg(reviewImg)
+//                            .reviewCnt(reviewCnt)
+//                            .build();
+//                })
+//                .collect(Collectors.toList());
+//    }
 
     @Transactional
     public void createMyCategory(User user, CreateMyCategoryRequest createMyCategory) {

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
@@ -25,7 +25,7 @@ public class PinServiceImpl implements PinService{
     @Transactional
     public void createPin(User user, Long myCategoryId, CreatePinRequest createPin) {
         MyCategory myCategory = myCategoryRepository.findByUserAndMyCategoryId(user, myCategoryId)
-                .orElseThrow(() -> new GeneralException(Code.MYCATEGORY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(Code.MY_CATEGORY_NOT_FOUND));
         Store store = storeRepository.findById(createPin.getStoreId())
                         .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    User findByNickname(String nickname);
+    Optional<User> findByNickname(String nickname);
 
     Optional<User> findByUserIdAndMemberStatusIs(UUID uuid, User.MemberStatus status);
 

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -20,6 +20,7 @@ public enum Code {
     USER_FOLLOW_NO_MORE_CONTENT(HttpStatus.NOT_FOUND, 404003, "리스트가 더이상 존재하지 않습니다."),
     USER_FOLLOW_ALREADY(HttpStatus.CONFLICT, 409002, "이미 팔로우했습니다."),
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
+    USER_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -20,7 +20,7 @@ public enum Code {
     USER_FOLLOW_NO_MORE_CONTENT(HttpStatus.NOT_FOUND, 404003, "리스트가 더이상 존재하지 않습니다."),
     USER_FOLLOW_ALREADY(HttpStatus.CONFLICT, 409002, "이미 팔로우했습니다."),
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
-    USER_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
+    USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -24,7 +24,7 @@ public enum Code {
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),
-    OPENINGHOURS_NOT_FOUND(HttpStatus.NOT_FOUND, 404102,"해당 가게에 대한 운영시간이 존재하지 않습니다."),
+    OPENING_HOURS_NOT_FOUND(HttpStatus.NOT_FOUND, 404102,"해당 가게에 대한 운영시간이 존재하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404103,"해당 가게에 대한 카테고리가 존재하지 않습니다."),
 
     //Review 관련 에러 +2
@@ -54,10 +54,10 @@ public enum Code {
     GROUPLIST_NOT_FROUND(HttpStatus.NOT_FOUND,403409,"존재하지 않는 그룹 내 상점입니다."),
   
     //myCategory 관련 에러 +5
-    MYCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),
+    MY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),
     PIN_NOT_FOUND(HttpStatus.NOT_FOUND, 404502,"존재하지 않는 찜 입니다"),
-    MYCATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, 409501, "이미 존재하는 카테고리입니다."),
-    USER_NO_PERMISSION_FOR_MYCATEGORY(HttpStatus.FORBIDDEN, 403501, "해당 유저는 해당 카테고리에 대한 권한이 없습니다."),
+    MY_CATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, 409501, "이미 존재하는 카테고리입니다."),
+    USER_NO_PERMISSION_FOR_MY_CATEGORY(HttpStatus.FORBIDDEN, 403501, "해당 유저는 해당 카테고리에 대한 권한이 없습니다."),
 
     // token 관련 에러 +6
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 401601, "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 위치 여부에 따라 API를 나눠 작성했던 것을 통일 / 내 카테고리 조회 시 내 닉네임을 사용하지 않고, 토큰으로 처리
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 서버가 클라이언트의 상태를 보존하지 않기 위해 **내 카테고리 조회 시 닉네임을 사용하지 않습니다**.
   - 위의 사항으로 인해 위치 기반 처리 시 reponse가 달라지는 부분이 없어, 위치 기반에 따라 작성했던 API를 기본 조회 API에서 조회될 수 있도록 통일했습니다. 

### 작업 내역

- 내 카테고리 조회 시 nickname을 받지 않는 경우가 발생해 쿼리로 받도록 엔드포인트를 변경했습니다.
- 내 닉네임을 통해 카테고리, 찜 가게 목록 조회가 불가능합니다.


### Issue Number 

close: #157

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
* 위치 기반이 아닌 경우와 위치 기반인 경우를 통합해 API를 작성했습니다. 도중 신경 쓰지 못한 예외사항 있을 수 있으니 리뷰 부탁드립니다!