### PR TITLE
chore: longitude, latitude의 data type을 double로 변경

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
@@ -17,9 +17,9 @@ public class RouteListResponse {
     public static class RouteList{
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Float longtitude;
+        private Double longitude;
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Float latitude;
+        private Double latitude;
         private Long routeListId;
         private Integer ordinal;
         private Long storeId;

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -91,7 +91,7 @@ public class RouteListServiceImpl implements RouteListService{
         List<RouteList> routeList = routeListRepository.findByRoute(route);
         return  routeList.stream().map(rL ->
                 RouteListResponse.RouteList.builder()
-                        .longtitude(rL.getStore().getLongitude())
+                        .longitude(rL.getStore().getLongitude())
                         .latitude(rL.getStore().getLatitude())
                         .routeListId(rL.getRouteListId())
                         .ordinal(rL.getOrdinal())

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -24,9 +24,11 @@ public class Store extends BaseTime {
     @Column(columnDefinition = "VARCHAR(30)")
     private String storeName;
 
-    private Float longitude;
+    @Column(columnDefinition = "DOUBLE(17,14)")
+    private Double longitude;
 
-    private Float latitude;
+    @Column(columnDefinition = "DOUBLE(17,15)")
+    private Double latitude;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "categoryId")

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 public class GetStoresInMapResponse{
     Long storeId;
     String storeName;
-    Float longitude;
-    Float latitude;
+    Double longitude;
+    Double latitude;
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 위도 및 경도의 datatype이 범위를 넘어가, 기존 float에서 double로 변경합니다.

### PR 특이 사항

- Store entity의 `longitude`, `latitude` 필드의 datatype이 변경됩니다.
