### PR TITLE
feat: 피드 검색 기능

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
@@ -9,7 +9,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +24,10 @@ public class FeedController {
     public ResponseEntity<?> getRandomFeed(@AuthenticationPrincipal AuthUser authUser){
         User user = authUser.getUser();
         return ResponseEntity.status(HttpStatus.OK).body(feedService.getRandomFeed(user));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchFeed(@RequestParam(name = "keyword", required = false) String keyword, @RequestParam(name = "hashTags", required = false) List<Long> hashTags){
+        return ResponseEntity.status(HttpStatus.OK).body(feedService.searchFeed(keyword, hashTags));
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/SearchFeedResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/SearchFeedResponse.java
@@ -1,0 +1,18 @@
+package com.umc.gusto.domain.review.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class SearchFeedResponse {
+    List<BasicViewResponse> reviews;
+
+    public static SearchFeedResponse of(List<BasicViewResponse> reviews){
+        return SearchFeedResponse.builder()
+                .reviews(reviews)
+                .build();
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -41,4 +41,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);
+
+    //검색 기능
+    @Query("SELECT r FROM Review r WHERE r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")
+    List<Review> searchByStoreContains(String keyword); //TODO: 후에 페이징 처리 하기
+    @Query("SELECT t.review FROM Tagging t WHERE t.review.store.storeName like concat('%', :keyword, '%') AND t.hashTag.hasTagId = :hashTagId")
+    List<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId);
+    @Query("SELECT t.review FROM Tagging t WHERE t.hashTag.hasTagId = :hashTagId")
+    List<Review> searchByHashTagContains(Long hashTagId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
@@ -1,10 +1,12 @@
 package com.umc.gusto.domain.review.service;
 
 import com.umc.gusto.domain.review.model.response.RandomFeedResponse;
+import com.umc.gusto.domain.review.model.response.SearchFeedResponse;
 import com.umc.gusto.domain.user.entity.User;
 
 import java.util.List;
 
 public interface FeedService {
     List<RandomFeedResponse> getRandomFeed(User user);
+    SearchFeedResponse searchFeed(String keyword, List<Long> hashTags);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -1,12 +1,15 @@
 package com.umc.gusto.domain.review.service;
 
 import com.umc.gusto.domain.review.entity.Review;
+import com.umc.gusto.domain.review.model.response.BasicViewResponse;
 import com.umc.gusto.domain.review.model.response.RandomFeedResponse;
+import com.umc.gusto.domain.review.model.response.SearchFeedResponse;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
 import com.umc.gusto.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,5 +23,25 @@ public class FeedServiceImpl implements FeedService{
         List<Review> feedList = reviewRepository.findRandomFeedByUser(user.getUserId());
 //        List<Review> feedList = new ArrayList<>();
         return feedList.stream().map(RandomFeedResponse::of).collect(Collectors.toList());
+    }
+
+    @Override
+    public SearchFeedResponse searchFeed(String keyword, List<Long> hashTags) {
+        List<Review> searchResult = new ArrayList<>();
+        //맛집과 해시태그를 함께 검색하는 경우
+        if(keyword!=null && hashTags!=null){
+            for(Long hashTagId: hashTags){
+                searchResult.addAll(reviewRepository.searchByStoreAndHashTagContains(keyword, hashTagId));
+            }
+        } else if(keyword!=null){ //맛집을 검색하는 경우
+            searchResult = reviewRepository.searchByStoreContains(keyword);
+        } else if(hashTags!=null){
+            for(Long hashTagId: hashTags){
+                searchResult.addAll(reviewRepository.searchByHashTagContains(hashTagId));
+            }
+        }
+
+        List<BasicViewResponse> basicViewResponse = searchResult.stream().map(BasicViewResponse::of).toList();
+        return SearchFeedResponse.of(basicViewResponse);
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
 - 피드 검색 시 맛집 이름 검색
 - 맛집 이름 + 해시태그 검색
  리뷰 가게가 구스또 파스타 가게이고 해시태그가 4인 리뷰를 반환합니다.
![image](https://github.com/gusto-umc/Gusto-Server/assets/54650556/89e01658-b1fc-4ca2-94ca-90006a32a058)
 - 해시태그 검색

### PR 특이 사항
 - Like in이 없어서 for문으로 여러 개의 해시태그를 검색합니다.
 - 아직 페이징 처리가 되어 있지 않습니다.

### Issue Number 
#163 