### PR TITLE
refactor : 리뷰 이미지가 없는 경우 "" 처리

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -97,8 +97,8 @@ public class MyCategoryServiceImpl implements MyCategoryService {
         return pinList.stream()                                     // townName을 기준으로 보일 수 있는 store가 포함된 pin만 보이기
                 .map(pin -> {
                     Store store = pin.getStore();
-                    Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);       // 가장 좋아요가 많은 review
-                    String reviewImg = topReviewOptional.map(Review::getImg1).orElse(null);                               // 가장 좋아요가 많은 review 이미지
+                    Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);               // 가장 좋아요가 많은 review
+                    String reviewImg = topReviewOptional.map(Review::getImg1).orElse("");                               // 가장 좋아요가 많은 review 이미지
                     Integer reviewCnt = reviewRepository.countByStoreAndUserNickname(store, finalUser.getNickname());                        // 내가 작성한 리뷰의 개수 == 방문 횟수
 
                     return  PinByMyCategoryResponse.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreResponse.java
@@ -21,8 +21,8 @@ public class GetStoreResponse{
     Long storeId;
     String storeName;
     String address;
-    Float longitude;
-    Float latitude;
+    Double longitude;
+    Double latitude;
     Map<OpeningHours.BusinessDay, Timing> businessDay;
     String contact;
     List<String> reviewImg3;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -107,10 +107,10 @@ public class StoreServiceImpl implements StoreService{
                         .nickname(reviewer.getNickname())
                         .liked(review.getLiked())
                         .comment(review.getComment())
-                        .img1(review.getImg1())
-                        .img2(review.getImg2())
-                        .img3(review.getImg3())
-                        .img4(review.getImg4())
+                        .img1(Optional.ofNullable(review.getImg1()).orElse(""))
+                        .img2(Optional.ofNullable(review.getImg2()).orElse(""))
+                        .img3(Optional.ofNullable(review.getImg3()).orElse(""))
+                        .img4(Optional.ofNullable(review.getImg4()).orElse(""))
                         .build();
                 })
                 .toList();

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -51,9 +51,8 @@ public class StoreServiceImpl implements StoreService{
         List<Review> top3Reviews = reviewRepository.findFirst3ByStoreOrderByLikedDesc(store);
 
         List<String> reviewImg = top3Reviews.stream()
-                .map(Review::getImg1)
+                .map(review -> Optional.ofNullable(review.getImg1()).orElse(""))
                 .collect(Collectors.toList());
-
         boolean isPinned = pinRepository.existsByUserAndStoreStoreId(user, storeId);
 
 
@@ -82,7 +81,7 @@ public class StoreServiceImpl implements StoreService{
         List<Review> top4Reviews = reviewRepository.findFirst4ByStoreOrderByLikedDesc(store);
 
         List<String> reviewImg = top4Reviews.stream()
-                .map(Review::getImg1)
+                .map(review -> Optional.ofNullable(review.getImg1()).orElse(""))
                 .collect(Collectors.toList());
 
         // reviews 페이징 처리 (3,6,6...)

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -107,10 +107,10 @@ public class StoreServiceImpl implements StoreService{
                         .nickname(reviewer.getNickname())
                         .liked(review.getLiked())
                         .comment(review.getComment())
-                        .img1(Optional.ofNullable(review.getImg1()).orElse(""))
-                        .img2(Optional.ofNullable(review.getImg2()).orElse(""))
-                        .img3(Optional.ofNullable(review.getImg3()).orElse(""))
-                        .img4(Optional.ofNullable(review.getImg4()).orElse(""))
+                        .img1(review.getImg1())
+                        .img2(review.getImg2())
+                        .img3(review.getImg3())
+                        .img4(review.getImg4())
                         .build();
                 })
                 .toList();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 리뷰 이미지가 없는 경우 "" 처리
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 리턴 값 통일을 위해 리뷰 이미지가 없는 경우 null이 아닌 ""처리를 합니다

### 작업 후 기대 동작(스크린샷)

- 카테고리 별 가게 목록 조회
<img width="593" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/2e22832f-f14d-457b-bae1-e9b25ef914c7">

- 가게 조회
<img width="590" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/9f381d3d-1268-42c4-ac28-6e03c0026716">

- 가게 상세 조회
<img width="589" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/d7bcf769-8fbe-4aff-92aa-8a1d9a3b4796">


### Issue Number 

close: #167
