### PR TITLE
refactor: 리뷰 이미지가 없을 경우 null이 아닌 ""로 반환

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreResponse.java
@@ -21,8 +21,8 @@ public class GetStoreResponse{
     Long storeId;
     String storeName;
     String address;
-    Float longitude;
-    Float latitude;
+    Double longitude;
+    Double latitude;
     Map<OpeningHours.BusinessDay, Timing> businessDay;
     String contact;
     List<String> reviewImg3;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -168,7 +168,7 @@ public class StoreServiceImpl implements StoreService{
         for (Pin pin : pins){
             Store store = pin.getStore();
             Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);
-            String reviewImg = topReviewOptional.map(Review::getImg1).orElse(null);
+            String reviewImg = topReviewOptional.map(Review::getImg1).orElse("");
             boolean hasVisited = reviewRepository.existsByStoreAndUserNickname(store, user.getNickname());
 
             GetStoreInfoResponse getStoreInfoResponse = GetStoreInfoResponse.builder()


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : [Store] 리뷰가 없을 경우 null이 아닌 ""로 반환 / 위도&경도 데이터 타입 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 가게 정보 return 시 가게 이미지를 가장 좋아요가 많은 리뷰 이미지로 반환
- but 리뷰 이미지가 없을 경우 기존에는 null을 반환했음 >> null이 아닌  ""로 반환하도록 통일 및 수정
- 위도&경도 데이터타입이 Double로 통일되지 않은 부분을 확인하여 수정

### 작업 후 기대 동작(스크린샷)

- 리뷰가 없을 경우 ""로 반환
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/13db21eb-d466-4649-ad8a-d2682e9a84f1)

### Issue Number 

close: #167 
