### PR TITLE
feat: 피드 상세 조회 API

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
@@ -29,7 +29,8 @@ public class FeedController {
     }
 
     @GetMapping("{reviewId}")
-    public ResponseEntity<?> getFeedDetail(@PathVariable(name = "reviewId") Long reviewId){
-        return ResponseEntity.status(HttpStatus.OK).body(feedService.getFeedDetail(reviewId));
+    public ResponseEntity<?> getFeedDetail(@AuthenticationPrincipal AuthUser authUser, @PathVariable(name = "reviewId") Long reviewId){
+        User user = authUser.getUser();
+        return ResponseEntity.status(HttpStatus.OK).body(feedService.getFeedDetail(user, reviewId));
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/controller/FeedController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,5 +26,10 @@ public class FeedController {
     @GetMapping("/search")
     public ResponseEntity<?> searchFeed(@RequestParam(name = "keyword", required = false) String keyword, @RequestParam(name = "hashTags", required = false) List<Long> hashTags){
         return ResponseEntity.status(HttpStatus.OK).body(feedService.searchFeed(keyword, hashTags));
+    }
+
+    @GetMapping("{reviewId}")
+    public ResponseEntity<?> getFeedDetail(@PathVariable(name = "reviewId") Long reviewId){
+        return ResponseEntity.status(HttpStatus.OK).body(feedService.getFeedDetail(reviewId));
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
@@ -15,6 +15,8 @@ public class FeedDetailResponse {
     String address;
     String nickName;
     String profileImage;
+    Integer likeCnt;
+    boolean liked;
     List<String> images;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String menuName;
@@ -31,15 +33,16 @@ public class FeedDetailResponse {
     Integer parking;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String comment;
-    Integer likeCnt;
 
-    public static FeedDetailResponse of(Review review, String hashTags){
+    public static FeedDetailResponse of(Review review, String hashTags, boolean liked){
         return FeedDetailResponse.builder()
                 .storeId(review.getStore().getStoreId())
                 .storeName(review.getStore().getStoreName())
                 .address(review.getStore().getAddress())
                 .nickName(review.getUser().getNickname())
                 .profileImage(review.getUser().getProfileImage())
+                .likeCnt(review.getLiked())
+                .liked(liked)
                 .images(review.getImageList())
                 .menuName(review.getMenuName())
                 .hashTags(hashTags)
@@ -49,7 +52,6 @@ public class FeedDetailResponse {
                 .toilet(review.getToilet())
                 .parking(review.getParking())
                 .comment(review.getComment())
-                .likeCnt(review.getLiked())
                 .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
@@ -1,0 +1,55 @@
+package com.umc.gusto.domain.review.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.umc.gusto.domain.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class FeedDetailResponse {
+    Long storeId;
+    String storeName;
+    String address;
+    String nickName;
+    String profileImage;
+    List<String> images;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String menuName;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String hashTags;
+    Integer taste;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Integer spiciness;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Integer mood;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Integer toilet;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Integer parking;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String comment;
+    Integer likeCnt;
+
+    public static FeedDetailResponse of(Review review, String hashTags){
+        return FeedDetailResponse.builder()
+                .storeId(review.getStore().getStoreId())
+                .storeName(review.getStore().getStoreName())
+                .address(review.getStore().getAddress())
+                .nickName(review.getUser().getNickname())
+                .profileImage(review.getUser().getProfileImage())
+                .images(review.getImageList())
+                .menuName(review.getMenuName())
+                .hashTags(hashTags)
+                .taste(review.getTaste())
+                .spiciness(review.getSpiciness())
+                .mood(review.getMood())
+                .toilet(review.getToilet())
+                .parking(review.getParking())
+                .comment(review.getComment())
+                .likeCnt(review.getLiked())
+                .build();
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
@@ -16,7 +16,7 @@ public class FeedDetailResponse {
     String nickName;
     String profileImage;
     Integer likeCnt;
-    boolean liked;
+    boolean likeCheck;
     List<String> images;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String menuName;
@@ -34,7 +34,7 @@ public class FeedDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String comment;
 
-    public static FeedDetailResponse of(Review review, String hashTags, boolean liked){
+    public static FeedDetailResponse of(Review review, String hashTags, boolean likeCheck){
         return FeedDetailResponse.builder()
                 .storeId(review.getStore().getStoreId())
                 .storeName(review.getStore().getStoreName())
@@ -42,7 +42,7 @@ public class FeedDetailResponse {
                 .nickName(review.getUser().getNickname())
                 .profileImage(review.getUser().getProfileImage())
                 .likeCnt(review.getLiked())
-                .liked(liked)
+                .likeCheck(likeCheck)
                 .images(review.getImageList())
                 .menuName(review.getMenuName())
                 .hashTags(hashTags)

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/LikedRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/LikedRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface LikedRepository extends JpaRepository<Liked, Long> {
     Optional<Liked> findByUserAndReview(User user, Review review);
+    boolean existsByUserAndReview(User user, Review review);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface FeedService {
     List<RandomFeedResponse> getRandomFeed(User user);
     SearchFeedResponse searchFeed(String keyword, List<Long> hashTags);
-    FeedDetailResponse getFeedDetail(Long reviewId);
+    FeedDetailResponse getFeedDetail(User user, Long reviewId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedService.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.review.service;
 
+import com.umc.gusto.domain.review.model.response.FeedDetailResponse;
 import com.umc.gusto.domain.review.model.response.RandomFeedResponse;
 import com.umc.gusto.domain.review.model.response.SearchFeedResponse;
 import com.umc.gusto.domain.user.entity.User;
@@ -9,4 +10,5 @@ import java.util.List;
 public interface FeedService {
     List<RandomFeedResponse> getRandomFeed(User user);
     SearchFeedResponse searchFeed(String keyword, List<Long> hashTags);
+    FeedDetailResponse getFeedDetail(Long reviewId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -64,8 +64,8 @@ public class FeedServiceImpl implements FeedService{
         hashTags.deleteCharAt(hashTags.length()-1);
 
         //이 리뷰를 보는 유저가 해당 리뷰를 좋아요했는지 체크
-        boolean liked = likedRepository.existsByUserAndReview(user, review);
+        boolean likeCheck = likedRepository.existsByUserAndReview(user, review);
 
-        return FeedDetailResponse.of(review, hashTags.toString(), liked);
+        return FeedDetailResponse.of(review, hashTags.toString(), likeCheck);
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -1,11 +1,13 @@
 package com.umc.gusto.domain.review.service;
 
 import com.umc.gusto.domain.review.entity.Review;
-import com.umc.gusto.domain.review.model.response.BasicViewResponse;
-import com.umc.gusto.domain.review.model.response.RandomFeedResponse;
-import com.umc.gusto.domain.review.model.response.SearchFeedResponse;
+import com.umc.gusto.domain.review.model.response.*;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
 import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.global.common.PublishStatus;
+import com.umc.gusto.global.exception.Code;
+import com.umc.gusto.global.exception.customException.NotFoundException;
+import com.umc.gusto.global.exception.customException.PrivateItemException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -43,5 +45,21 @@ public class FeedServiceImpl implements FeedService{
 
         List<BasicViewResponse> basicViewResponse = searchResult.stream().map(BasicViewResponse::of).toList();
         return SearchFeedResponse.of(basicViewResponse);
+    }
+
+    @Override
+    public FeedDetailResponse getFeedDetail(Long reviewId) {
+        //TOOD: reviewServiceImpl와 중복되는 코드
+        Review review = reviewRepository.findById(reviewId).orElseThrow(()->new NotFoundException(Code.REVIEW_NOT_FOUND));
+        //TODO: 후에 각 리뷰마다의 공개, 비공개를 확인해서 주는거로 수정하기
+        if(!review.getUser().getPublishReview().equals(PublishStatus.PUBLIC)){
+            throw new PrivateItemException(Code.NO_PUBLIC_REVIEW);
+        }
+
+        StringBuilder hashTags = new StringBuilder();
+        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(o-> hashTags.append(o).append(","));
+        //마지막 문자 , 제거
+        hashTags.deleteCharAt(hashTags.length()-1);
+        return FeedDetailResponse.of(review, hashTags.toString());
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -31,7 +31,7 @@ public enum Code {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, 404201, "존재하지 않는 리뷰입니다."),
     HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, 404202, "존재하지 않는 해시태그입니다."),
     USER_NO_PERMISSION_FOR_REVIEW(HttpStatus.FORBIDDEN, 403203, "해당 유저는 해당 리뷰에 대한 권한이 없습니다."),
-    NO_PUBLIC_REVIEW(HttpStatus.FORBIDDEN, 403204, "해당 리뷰는 public입니다."),
+    NO_PUBLIC_REVIEW(HttpStatus.FORBIDDEN, 403204, "해당 리뷰는 private입니다."),
     NO_ONESELF_LIKE(HttpStatus.BAD_REQUEST, 400204, "자기자신의 리뷰는 좋아요할 수 없습니다."),
     NO_LIKE_REVIEW(HttpStatus.BAD_REQUEST, 400205, "해당 리뷰에 좋아요를 한 적이 없습니다."),
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
리뷰 1건 조회 API과 똑같은 로직에서 리뷰의 작성자 정보, 해당 리뷰를 보는 유저가 좋아요를 한 적이 있는지 여부 데이터 포함하도록 만들었습니다. 

### Issue Number 
#172 

### 어떤 점에 
리뷰 1건 조회 API와 비즈니스 로직은 거의 다른게 없기 때문에 중복 코드가 발생합니다. 따로 함수로 빼고 싶으나 review, hashTag 두개의 값을 return해야하기 때문에 좋은 코드가 생각이 안나서 수정하지 못했습니다. 