### PR TITLE
fix: 리뷰 생성과 조회 시 해시 태그가 없으면 에러 발생하는 부분 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
@@ -49,4 +49,21 @@ public class ReviewDetailResponse {
                 .likeCnt(review.getLiked())
                 .build();
     }
+
+    public static ReviewDetailResponse of(Review review){
+        return ReviewDetailResponse.builder()
+                .storeId(review.getStore().getStoreId())
+                .storeName(review.getStore().getStoreName())
+                .visitedAt(review.getVisitedAt())
+                .images(review.getImageList())
+                .menuName(review.getMenuName())
+                .taste(review.getTaste())
+                .spiciness(review.getSpiciness())
+                .mood(review.getMood())
+                .toilet(review.getToilet())
+                .parking(review.getParking())
+                .comment(review.getComment())
+                .likeCnt(review.getLiked())
+                .build();
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -146,11 +146,16 @@ public class ReviewServiceImpl implements ReviewService{
             throw new PrivateItemException(Code.NO_PUBLIC_REVIEW);
         }
 
-        StringBuilder hashTags = new StringBuilder();
-        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(o-> hashTags.append(o).append(","));
-        //마지막 문자 , 제거
-        hashTags.deleteCharAt(hashTags.length()-1);
-        return ReviewDetailResponse.of(review, hashTags.toString());
+        boolean hashTagEmpty = review.getTaggingSet().isEmpty(); //true면 해시태그 없음
+        if(!hashTagEmpty) {
+            StringBuilder hashTags = new StringBuilder();
+            review.getTaggingSet().stream().map(r -> r.getHashTag().getHasTagId()).forEach(o -> hashTags.append(o).append(","));
+            //마지막 문자 , 제거
+            hashTags.deleteCharAt(hashTags.length() - 1);
+            return ReviewDetailResponse.of(review, hashTags.toString());
+        }else{
+            return ReviewDetailResponse.of(review);
+        }
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -73,8 +73,10 @@ public class ReviewServiceImpl implements ReviewService{
         }
 
         //리뷰와 해시태그 연결
-        String[] hashTags = createReviewRequest.getHashTagId().split(",");
-        connectHashTag(review, hashTags);
+        if(createReviewRequest.getHashTagId()!=null){
+            String[] hashTags = createReviewRequest.getHashTagId().split(",");
+            connectHashTag(review, hashTags);
+        }
 
         reviewRepository.save(review);
     }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
 - 리뷰 생성할 때, 해시 태그를 입력하지 않아도 되지만, 현재는 해시 태그를 입력하지 않으면 에러가 발생했습니다. 
 - 리뷰 조회할 때, 리뷰의 해시 태그가 없을 경우 에러가 발생했습니다. 
해당 부분을 해시 태그과 관련없이 생성, 조회가 가능하도록 했습니다. 

### Issue Number 
close: #37