### PR TITLE
refactor: 리뷰 대표 이미지만 넘기도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/BasicViewResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/BasicViewResponse.java
@@ -4,18 +4,16 @@ import com.umc.gusto.domain.review.entity.Review;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Builder
 @Getter
 public class BasicViewResponse {
     Long reviewId;
-    List<String> images;
+    String images;
 
     public static BasicViewResponse of(Review review){
         return BasicViewResponse.builder()
                 .reviewId(review.getReviewId())
-                .images(review.getImageList())
+                .images(review.getImg1())
                 .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/CalendarViewResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/CalendarViewResponse.java
@@ -5,20 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Builder
 @Getter
 public class CalendarViewResponse { //TODO: 데모데이 후 원래 캘린더 뷰 화면으로 사용하기 위해서 만든 DTO
     Long reviewId;
     LocalDate visitedDate;
-    List<String> images;
+    String images;
 
     public static CalendarViewResponse of(Review review){
         return CalendarViewResponse.builder()
                 .reviewId(review.getReviewId())
                 .visitedDate(review.getVisitedAt())
-                .images(review.getImageList())
+                .images(review.getImg1())
                 .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/RandomFeedResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/RandomFeedResponse.java
@@ -4,18 +4,16 @@ import com.umc.gusto.domain.review.entity.Review;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @Builder
 public class RandomFeedResponse {
     Long reviewId;
-    List<String> images;
+    String images;
 
     public static RandomFeedResponse of(Review review){
         return RandomFeedResponse.builder()
                 .reviewId(review.getReviewId())
-                .images(review.getImageList())
+                .images(review.getImg1())
                 .build();
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
인스타뷰, 캘린더뷰, 타인 리뷰 모아보기, 먹스또 랜덤 피드는 대표 이미지 한 개만 필요합니다. 
기존에는 리뷰의 모든 이미지를 보내서 서버 부하를 줄이고자 변경했습니다.

### 작업 내역
응답 이미지 데이터 형태 변경

### Issue Number 
#152 
