### PR TITLE
refactor : store entity 내에 categoryString 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -24,7 +24,7 @@ public class Store extends BaseTime {
     @Column(columnDefinition = "VARCHAR(30)")
     private String storeName;
 
-    @Column(columnDefinition = "DOUBLE(17,14)")
+    @Column(columnDefinition = "DOUBLE(17,15)")
     private Double longitude;
 
     @Column(columnDefinition = "DOUBLE(17,15)")
@@ -33,7 +33,8 @@ public class Store extends BaseTime {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "categoryId")
     private Category category;
-    
+
+    @Column(columnDefinition = "VARCHAR(20)")
     private String categoryString;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -33,8 +33,7 @@ public class Store extends BaseTime {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "categoryId")
     private Category category;
-
-    @Column(nullable = false)
+    
     private String categoryString;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/entity/Store.java
@@ -34,6 +34,9 @@ public class Store extends BaseTime {
     @JoinColumn(name = "categoryId")
     private Category category;
 
+    @Column(nullable = false)
+    private String categoryString;
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "stateId", nullable = false)
     private State state;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : store entity에 categoryString 필드 추가
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 가게 정보 API를 불러오는 과정에서 간단한 처리를 위해 category 테이블에서 매핑 값을 가져오는 대신 store entity에 categoryString을 필드로 생성해 사용한다.


### Issue Number 

close: #176
