### PR TITLE
feat:루트 내 경로 항목 삭제 시 자동으로 순서 조정  /refactor:루트 리팩토링(DTO형식,API 주석)

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -49,9 +49,7 @@ public class GroupServiceImpl implements GroupService{
     private final InvitationCodeRepository invitationCodeRepository;
     private final GroupListRepository groupListRepository;
     private final RouteRepository routeRepository;
-  
     private static final int INVITE_CODE_LENGTH = 12;
-
     private final StoreRepository storeRepository;
     private final ReviewRepository reviewRepository;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.route.controller;
 
+import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.request.RouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteResponse;
 import com.umc.gusto.domain.route.service.RouteService;
@@ -19,6 +20,10 @@ import java.util.List;
 public class RouteController {
     private final RouteService routeService;
 
+    /**
+     * 루트 생성/그룹 내 루트 추가
+     * [POST] /routes
+     */
     // 루트 생성
     @PostMapping("")
     public ResponseEntity<?> createRoute(
@@ -29,7 +34,10 @@ public class RouteController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    // 루트 삭제
+    /**
+     * 내 루트 삭제
+     * [DELETE] /routes/{routeId}
+     */
     @DeleteMapping("/{routeId}")
     public ResponseEntity<?> deleteRoute(
             @PathVariable Long routeId,
@@ -39,7 +47,10 @@ public class RouteController {
         return ResponseEntity.ok().build();
     }
 
-    // 내 루트 조회
+    /**
+     * 내 루트 조회
+     * [GET] /routes
+     */
     @GetMapping("")
     public ResponseEntity<List<RouteResponse.RouteResponseDto>> allMyRoute(
             @AuthenticationPrincipal AuthUser authUSer
@@ -48,13 +59,25 @@ public class RouteController {
         return ResponseEntity.ok().body(route);
     }
 
-    // 그룹 내 루트 조회
+    /**
+     * 그룹 내 루트 목록
+     * [GET] /routes/groups{groupId}
+     */
     @GetMapping("/groups/{groupId}")
     public ResponseEntity<List<RouteResponse.RouteResponseDto>> allMyRoute(@PathVariable Long groupId){
         List<RouteResponse.RouteResponseDto> route = routeService.getGroupRoute(groupId);
         return ResponseEntity.ok().body(route);
     }
 
+    /**
+     * 루트 수정
+     * /{routeId}
+     */
+    @PatchMapping("/{routeId}")
+    public ResponseEntity<?> modifyRoute(@PathVariable Long routeId, @RequestBody ModifyRouteRequest request){
+        routeService.modifyRouteList(routeId,request);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
 
 
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -27,7 +27,7 @@ public class RouteController {
     // 루트 생성
     @PostMapping("")
     public ResponseEntity<?> createRoute(
-            @RequestBody RouteRequest.createRouteDto request,
+            @RequestBody RouteRequest request,
             @AuthenticationPrincipal AuthUser authUSer)
     {
         routeService.createRoute(request,authUSer.getUser());
@@ -52,10 +52,10 @@ public class RouteController {
      * [GET] /routes
      */
     @GetMapping("")
-    public ResponseEntity<List<RouteResponse.RouteResponseDto>> allMyRoute(
+    public ResponseEntity<List<RouteResponse>> allMyRoute(
             @AuthenticationPrincipal AuthUser authUSer
     ){
-        List<RouteResponse.RouteResponseDto> route = routeService.getRoute(authUSer.getUser());
+        List<RouteResponse> route = routeService.getRoute(authUSer.getUser());
         return ResponseEntity.ok().body(route);
     }
 
@@ -64,8 +64,8 @@ public class RouteController {
      * [GET] /routes/groups{groupId}
      */
     @GetMapping("/groups/{groupId}")
-    public ResponseEntity<List<RouteResponse.RouteResponseDto>> allMyRoute(@PathVariable Long groupId){
-        List<RouteResponse.RouteResponseDto> route = routeService.getGroupRoute(groupId);
+    public ResponseEntity<List<RouteResponse>> allMyRoute(@PathVariable Long groupId){
+        List<RouteResponse> route = routeService.getGroupRoute(groupId);
         return ResponseEntity.ok().body(route);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -49,7 +49,7 @@ public class RouteController {
     }
 
     // 그룹 내 루트 조회
-    @GetMapping("/{groupId}")
+    @GetMapping("/groups/{groupId}")
     public ResponseEntity<List<RouteResponse.RouteResponseDto>> allMyRoute(@PathVariable Long groupId){
         List<RouteResponse.RouteResponseDto> route = routeService.getGroupRoute(groupId);
         return ResponseEntity.ok().body(route);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -29,7 +29,7 @@ public class RouteListController {
     public ResponseEntity<?> createRouteList
     (@PathVariable Long routeId,
      @RequestParam(required = false) Long groupId,
-     @RequestBody @Valid List<RouteListRequest.createRouteListDto> request,
+     @RequestBody @Valid List<RouteListRequest> request,
      @AuthenticationPrincipal AuthUser authUSer
     ){
         routeListService.createRouteList(groupId,routeId,request,authUSer.getUser());
@@ -54,7 +54,7 @@ public class RouteListController {
      * [GET] /routeLists/{routeId}/order
      */
     @GetMapping("/{routeId}/order")
-    public ResponseEntity<List<RouteListResponse.RouteList>> getRouteListOrder(
+    public ResponseEntity<List<RouteListResponse>> getRouteListOrder(
             @PathVariable Long routeId)
     {
         return ResponseEntity.ok().body(routeListService.getRouteListDistance(routeId));

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -2,13 +2,11 @@ package com.umc.gusto.domain.route.controller;
 
 
 import com.umc.gusto.domain.route.model.request.RouteListRequest;
-import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
 import com.umc.gusto.domain.route.service.RouteListService;
 import com.umc.gusto.global.auth.model.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -23,7 +21,10 @@ public class RouteListController {
 
     private final RouteListService routeListService;
 
-    // 루트리스트만 추가
+    /**
+     * 루트 내 식당만 추가 == 루트리스트만 추가
+     * [POST] /routeLists/{routeId}
+     */
     @PostMapping("/{routeId}")
     public ResponseEntity<?> createRouteList
     (@PathVariable Long routeId,
@@ -35,7 +36,10 @@ public class RouteListController {
         return ResponseEntity.ok().build();
     }
 
-    // 루르리스트 항목 삭제
+    /**
+     * 루트 내 식당 삭제 == 루트 내 경로 삭제
+     * [DELETE] /routeLists/{routeId}
+     */
     @DeleteMapping("/{routeListId}")
     public ResponseEntity<?> deleteRouteLis(
             @PathVariable Long routeListId,
@@ -45,7 +49,10 @@ public class RouteListController {
         return ResponseEntity.ok().build();
     }
 
-    // 루트리스트 간 거리 조회
+    /**
+     * 내 루트/그룹 루트 간 거리 조회
+     * [GET] /routeLists/{routeId}/order
+     */
     @GetMapping("/{routeId}/order")
     public ResponseEntity<List<RouteListResponse.RouteList>> getRouteListOrder(
             @PathVariable Long routeId)
@@ -63,10 +70,5 @@ public class RouteListController {
         return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,authUSer.getUser(),groupId));
     }
 
-    // 루트 수정
-    @PatchMapping("/{routeId}")
-    public ResponseEntity<?> modifyRoute(@PathVariable Long routeId, @RequestBody ModifyRouteRequest request){
-        routeListService.modifyRouteList(routeId,request);
-        return ResponseEntity.ok(HttpStatus.OK);
-    }
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/ModifyRouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/ModifyRouteRequest.java
@@ -2,10 +2,12 @@ package com.umc.gusto.domain.route.model.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 public class ModifyRouteRequest {
     @NotBlank(message = "루트 명은 필수 입력값입니다.")
     private String routeName;

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
@@ -5,16 +5,13 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+@Getter
 public class RouteListRequest {
+    @NotNull(message = "루트 작성 시 식당 입력은 필수입니다.")
+    private Long storeId;
 
-    @Getter
-    public static class createRouteListDto{
-        @NotNull(message = "루트 작성 시 식당 입력은 필수입니다.")
-        private Long storeId;
-
-        @NotNull(message = "루트 작성 시 식당 순서를 기입해주세요.")
-        @DecimalMin(value = "1", message = "이동 순서가 1보다 작을 수 없습니다.")
-        @DecimalMax(value = "6", message = "이동 순서가 6보다 클 수 없습니다.")
-        private Integer ordinal;
-    }
+    @NotNull(message = "루트 작성 시 식당 순서를 기입해주세요.")
+    @DecimalMin(value = "1", message = "이동 순서가 1보다 작을 수 없습니다.")
+    @DecimalMax(value = "6", message = "이동 순서가 6보다 클 수 없습니다.")
+    private Integer ordinal;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
@@ -5,17 +5,10 @@ import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 public class RouteRequest {
-
-    @Getter
-    public static class createRouteDto{
-
-        @NotBlank(message = "루트 명은 필수 입력값입니다.")
-        private String routeName;
-        private Long groupId;
-        private List<RouteListRequest.createRouteListDto> routeList;
-
-    }
-
-
+    @NotBlank(message = "루트 명은 필수 입력값입니다.")
+    private String routeName;
+    private Long groupId;
+    private List<RouteListRequest> routeList;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteListResponse.java
@@ -6,40 +6,20 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class RouteListResponse {
-
-    @Builder
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class RouteList{
-
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Double longitude;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private Double latitude;
-        private Long routeListId;
-        private Integer ordinal;
-        private Long storeId;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private String storeName;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private String address;
-
-}
-
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
-    public static class RouteListResponseDto{
-        private Long routeId;
-        private String routeName;
-        private List<RouteList> routes;
-    }
-
-
-
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Double longitude;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Double latitude;
+    private Long routeListId;
+    private Integer ordinal;
+    private Long storeId;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String storeName;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String address;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteRouteListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteRouteListResponse.java
@@ -1,19 +1,18 @@
 package com.umc.gusto.domain.route.model.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class RouteResponse {
+public class RouteRouteListResponse {
     private Long routeId;
     private String routeName;
-    private int numStore;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Long groupId;
+    private List<RouteListResponse> routes;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.route.service;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.model.request.RouteListRequest;
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
+import com.umc.gusto.domain.route.model.response.RouteRouteListResponse;
 import com.umc.gusto.domain.user.entity.User;
 
 import java.util.List;
@@ -11,18 +12,18 @@ import java.util.List;
 public interface RouteListService {
 
     // 루트 리스트 생성
-    void createRouteList(Route route, List<RouteListRequest.createRouteListDto> request);
+    void createRouteList(Route route, List<RouteListRequest> request);
 
     // 루트 리스트만 생성
-    void createRouteList(Long groupId,Long routeId, List<RouteListRequest.createRouteListDto> request,User user);
+    void createRouteList(Long groupId,Long routeId, List<RouteListRequest> request,User user);
 
     // 루트 리스트 항목 삭제
     void deleteRouteList(Long routeListId, User user);
 
     // 리스트 거리 조회
-    List<RouteListResponse.RouteList> getRouteListDistance(Long routeId);
+    List<RouteListResponse> getRouteListDistance(Long routeId);
 
     // 루트 상세 조회
-    RouteListResponse.RouteListResponseDto getRouteListDetail(Long routeId,User user, Long groupId);
+    RouteRouteListResponse getRouteListDetail(Long routeId, User user, Long groupId);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
@@ -1,12 +1,9 @@
 package com.umc.gusto.domain.route.service;
 
 import com.umc.gusto.domain.route.entity.Route;
-import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.request.RouteListRequest;
-import com.umc.gusto.domain.route.model.request.RouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
 import com.umc.gusto.domain.user.entity.User;
-
 
 import java.util.List;
 
@@ -27,8 +24,5 @@ public interface RouteListService {
 
     // 루트 상세 조회
     RouteListResponse.RouteListResponseDto getRouteListDetail(Long routeId,User user, Long groupId);
-
-    // 루트 상세 수정
-    void modifyRouteList(Long routeId,ModifyRouteRequest request);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -5,13 +5,10 @@ import com.umc.gusto.domain.group.repository.GroupMemberRepository;
 import com.umc.gusto.domain.group.repository.GroupRepository;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.entity.RouteList;
-import com.umc.gusto.domain.route.model.request.ModifyRoueListRequest;
-import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.request.RouteListRequest;
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
 import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
-import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
@@ -150,43 +147,7 @@ public class RouteListServiceImpl implements RouteListService{
 
     }
 
-    @Transactional
-    @Override
-    public void modifyRouteList(Long routeId, ModifyRouteRequest request) {
-        // 루트리스트 갯수가 6개 이하인지 확인
-        // TODO: 루트 리스트.size()가 null 일때,즉 입력 시 루트리스트가 없을 때
-        if (request.getRouteList().size() >= 7) {
-            throw new GeneralException(Code.ROUTELIST_TO_MANY_REQUEST);
-        }
 
-        // 루트 존재 여부 확인
-        Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
-                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
-
-        // 루트 이름 변경 확인
-        if (request.getRouteName() != null) {
-            route.updateRouteName(request.getRouteName());
-        }
-
-        for (ModifyRoueListRequest modifyRoueListRequest : request.getRouteList()) {
-            // 변경된 PK값 확인
-            if (modifyRoueListRequest.getRouteListId() != null) {
-                // 해당 루트리스트 조회
-                RouteList routeList = routeListRepository.findById(modifyRoueListRequest.getRouteListId())
-                        .orElseThrow(() -> new GeneralException(Code.ROUTELIST_NOT_FOUND));
-
-                // 루트리스트 내 수정된 컬럼 값만 업데이트 진행
-                if (modifyRoueListRequest.getOrdinal() != null) {
-                    routeList.updateOrdinal(modifyRoueListRequest.getOrdinal());
-                }
-                if (modifyRoueListRequest.getStoreId() != null) {
-                    Store store = storeRepository.findById(modifyRoueListRequest.getStoreId())
-                            .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
-                    routeList.updateStore(store);
-                }
-            }
-        }
-    }
 
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -15,6 +15,7 @@ import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
+import com.umc.gusto.global.common.PublishStatus;
 import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
 import com.umc.gusto.global.exception.customException.NotFoundException;
@@ -123,8 +124,13 @@ public class RouteListServiceImpl implements RouteListService{
             }
         }
 
-
         Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE).orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
+
+        //유저 활성화 설정 반영
+        if(!route.getUser().getPublishRoute().equals(PublishStatus.PUBLIC)){
+            throw new GeneralException(Code.NO_PUBLIC_ROUTE);
+        }
+
         List<RouteList> routeList = routeListRepository.findByRoute(route);
         List<RouteListResponse.RouteList> routeLists = routeList.stream().map(rL ->
                 RouteListResponse.RouteList.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -80,10 +80,21 @@ public class RouteListServiceImpl implements RouteListService{
     @Transactional
     @Override
     public void deleteRouteList(Long routeListId, User user) {
-        RouteList routeList = routeListRepository.findById(routeListId).orElseThrow(() -> new NotFoundException(Code.ROUTELIST_NOT_FOUND));
-        routeListRepository.delete(routeList);
+        RouteList deleteRouteList = routeListRepository.findById(routeListId).orElseThrow(() -> new NotFoundException(Code.ROUTELIST_NOT_FOUND));
+        routeListRepository.delete(deleteRouteList);
 
+        Route route = routeRepository.findRouteByRouteIdAndStatus(deleteRouteList.getRoute().getRouteId(), BaseEntity.Status.ACTIVE)
+                .orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
+
+        List<RouteList> routeLists = routeListRepository.findByRoute(route);
+        for (RouteList list : routeLists) {
+            // 삭제된 아이템의 순서보다 큰 아이템들의 순서를 조정
+            if(deleteRouteList.getOrdinal()< list.getOrdinal() && list.getOrdinal() >1)
+                list.updateOrdinal(list.getOrdinal()-1);
+
+        }
     }
+
 
     @Override
     public List<RouteListResponse.RouteList> getRouteListDistance(Long routeId) {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.entity.RouteList;
 import com.umc.gusto.domain.route.model.request.RouteListRequest;
 import com.umc.gusto.domain.route.model.response.RouteListResponse;
+import com.umc.gusto.domain.route.model.response.RouteRouteListResponse;
 import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
 import com.umc.gusto.domain.store.repository.StoreRepository;
@@ -35,7 +36,7 @@ public class RouteListServiceImpl implements RouteListService{
 
     @Transactional
     @Override
-    public void createRouteList(Route route, List<RouteListRequest.createRouteListDto> request) {
+    public void createRouteList(Route route, List<RouteListRequest> request) {
         //루트리스트 생성
         request.forEach(dto -> {
             if(dto.getOrdinal() >= 1 && dto.getOrdinal() <= 6){
@@ -53,7 +54,7 @@ public class RouteListServiceImpl implements RouteListService{
     // 루트리스트만 추가
     @Transactional
     @Override
-    public void createRouteList(Long groupId,Long routeId, List<RouteListRequest.createRouteListDto> request,User user) {
+    public void createRouteList(Long groupId,Long routeId, List<RouteListRequest> request,User user) {
         if(groupId != null){
             Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
                     .orElseThrow(() -> new GeneralException(Code.FIND_FAIL_GROUP));
@@ -95,11 +96,11 @@ public class RouteListServiceImpl implements RouteListService{
 
 
     @Override
-    public List<RouteListResponse.RouteList> getRouteListDistance(Long routeId) {
+    public List<RouteListResponse> getRouteListDistance(Long routeId) {
         Route route = routeRepository.findRouteByRouteIdAndStatus(routeId,BaseEntity.Status.ACTIVE).orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
         List<RouteList> routeList = routeListRepository.findByRoute(route);
         return  routeList.stream().map(rL ->
-                RouteListResponse.RouteList.builder()
+                RouteListResponse.builder()
                         .longitude(rL.getStore().getLongitude())
                         .latitude(rL.getStore().getLatitude())
                         .routeListId(rL.getRouteListId())
@@ -111,7 +112,7 @@ public class RouteListServiceImpl implements RouteListService{
     }
 
     @Override
-    public RouteListResponse.RouteListResponseDto getRouteListDetail(Long routeId,User user, Long groupId) {
+    public RouteRouteListResponse getRouteListDetail(Long routeId, User user, Long groupId) {
         // 그룹 내 루트 상세 조회인 경우에만
         if(groupId != null){
             Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
@@ -129,8 +130,8 @@ public class RouteListServiceImpl implements RouteListService{
         }
 
         List<RouteList> routeList = routeListRepository.findByRoute(route);
-        List<RouteListResponse.RouteList> routeLists = routeList.stream().map(rL ->
-                RouteListResponse.RouteList.builder()
+        List<RouteListResponse> routeLists = routeList.stream().map(rL ->
+                RouteListResponse.builder()
                         .routeListId(rL.getRouteListId())
                         .storeId(rL.getStore().getStoreId())
                         .storeName(rL.getStore().getStoreName())
@@ -139,7 +140,7 @@ public class RouteListServiceImpl implements RouteListService{
                         .build()
         ).toList();
 
-        return RouteListResponse.RouteListResponseDto.builder()
+        return RouteRouteListResponse.builder()
                 .routeId(route.getRouteId())
                 .routeName(route.getRouteName())
                 .routes(routeLists)

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -9,16 +9,16 @@ import java.util.List;
 
 public interface RouteService {
     // 루트 생성
-    void createRoute(RouteRequest.createRouteDto request,User user);
+    void createRoute(RouteRequest request,User user);
 
     // 루트 삭제
     void deleteRoute(Long routeId,User user);
 
     // 내 루트 조회
-    List<RouteResponse.RouteResponseDto> getRoute(User user);
+    List<RouteResponse> getRoute(User user);
 
     // 그룹 내 루트 조회
-    List<RouteResponse.RouteResponseDto> getGroupRoute(Long groupId );
+    List<RouteResponse> getGroupRoute(Long groupId );
 
     // 루트 상세 수정
     void modifyRouteList(Long routeId, ModifyRouteRequest request);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.route.service;
 
+import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.request.RouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteResponse;
 import com.umc.gusto.domain.user.entity.User;
@@ -18,4 +19,7 @@ public interface RouteService {
 
     // 그룹 내 루트 조회
     List<RouteResponse.RouteResponseDto> getGroupRoute(Long groupId );
+
+    // 루트 상세 수정
+    void modifyRouteList(Long routeId, ModifyRouteRequest request);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -8,6 +8,7 @@ import com.umc.gusto.domain.route.model.response.RouteResponse;
 import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
 import com.umc.gusto.domain.user.entity.User;
+import com.umc.gusto.domain.user.repository.UserRepository;
 import com.umc.gusto.global.common.BaseEntity;
 import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
@@ -27,6 +28,7 @@ public class RouteServiceImpl implements RouteService{
     private final GroupRepository groupRepository;
     private final RouteListRepository routeListRepository;
     private final RouteListService routeListService;
+    private final UserRepository userRepository;
 
     @Transactional
     @Override
@@ -78,6 +80,8 @@ public class RouteServiceImpl implements RouteService{
     @Override
     public List<RouteResponse.RouteResponseDto> getRoute(User user) {
         //TODO 유저 관련 에러처리 추가하기
+        userRepository.findByNicknameAndMemberStatusIs(user.getNickname(), User.MemberStatus.ACTIVE)
+                .orElseThrow(()->new GeneralException(Code.DONT_EXIST_USER));
         //TODO: 유저 활성화 설정 반영
 
         List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -3,10 +3,15 @@ package com.umc.gusto.domain.route.service;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.repository.GroupRepository;
 import com.umc.gusto.domain.route.entity.Route;
+import com.umc.gusto.domain.route.entity.RouteList;
+import com.umc.gusto.domain.route.model.request.ModifyRoueListRequest;
+import com.umc.gusto.domain.route.model.request.ModifyRouteRequest;
 import com.umc.gusto.domain.route.model.request.RouteRequest;
 import com.umc.gusto.domain.route.model.response.RouteResponse;
 import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
+import com.umc.gusto.domain.store.entity.Store;
+import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.repository.UserRepository;
 import com.umc.gusto.global.common.BaseEntity;
@@ -30,6 +35,8 @@ public class RouteServiceImpl implements RouteService{
     private final RouteListRepository routeListRepository;
     private final RouteListService routeListService;
     private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
 
     @Transactional
     @Override
@@ -118,5 +125,43 @@ public class RouteServiceImpl implements RouteService{
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    @Override
+    public void modifyRouteList(Long routeId, ModifyRouteRequest request) {
+        // 루트리스트 갯수가 6개 이하인지 확인
+        // TODO: 루트 리스트.size()가 null 일때,즉 입력 시 루트리스트가 없을 때
+        
+        if (request.getRouteList().size() >= 7) {
+            throw new GeneralException(Code.ROUTELIST_TO_MANY_REQUEST);
+        }
+
+        // 루트 존재 여부 확인
+        Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
+
+        // 루트 이름 변경 확인
+        if (request.getRouteName() != null) {
+            route.updateRouteName(request.getRouteName());
+        }
+
+        for (ModifyRoueListRequest modifyRoueListRequest : request.getRouteList()) {
+            // 변경된 PK값 확인
+            if (modifyRoueListRequest.getRouteListId() != null) {
+                // 해당 루트리스트 조회
+                RouteList routeList = routeListRepository.findById(modifyRoueListRequest.getRouteListId())
+                        .orElseThrow(() -> new GeneralException(Code.ROUTELIST_NOT_FOUND));
+
+                // 루트리스트 내 수정된 컬럼 값만 업데이트 진행
+                if (modifyRoueListRequest.getOrdinal() != null) {
+                    routeList.updateOrdinal(modifyRoueListRequest.getOrdinal());
+                }
+                if (modifyRoueListRequest.getStoreId() != null) {
+                    Store store = storeRepository.findById(modifyRoueListRequest.getStoreId())
+                            .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
+                    routeList.updateStore(store);
+                }
+            }
+        }
+    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -128,9 +129,14 @@ public class RouteServiceImpl implements RouteService{
     @Transactional
     @Override
     public void modifyRouteList(Long routeId, ModifyRouteRequest request) {
+
+        // 루트 리스트.size()가 null 일때,즉 루트명만 수정 시
+        if (request.getRouteList() == null) {
+            // 빈 리스트로 routeList를 초기화합니다.
+            request.setRouteList(Collections.emptyList());
+        }
+
         // 루트리스트 갯수가 6개 이하인지 확인
-        // TODO: 루트 리스트.size()가 null 일때,즉 입력 시 루트리스트가 없을 때
-        
         if (request.getRouteList().size() >= 7) {
             throw new GeneralException(Code.ROUTELIST_TO_MANY_REQUEST);
         }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -77,6 +77,9 @@ public class RouteServiceImpl implements RouteService{
 
     @Override
     public List<RouteResponse.RouteResponseDto> getRoute(User user) {
+        //TODO 유저 관련 에러처리 추가하기
+        //TODO: 유저 활성화 설정 반영
+
         List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);
         return routes.stream().map(
                         Route -> RouteResponse.RouteResponseDto.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -41,7 +41,7 @@ public class RouteServiceImpl implements RouteService{
 
     @Transactional
     @Override
-    public void createRoute(RouteRequest.createRouteDto request,User user) {
+    public void createRoute(RouteRequest request,User user) {
         // 루트명은 내 루트명 중에서 중복 불가능
         if (routeRepository.existsByRouteName(request.getRouteName(),BaseEntity.Status.ACTIVE,user)) {
             throw new GeneralException(Code.ROUTE_DUPLICATE_ROUTENAME);
@@ -87,7 +87,7 @@ public class RouteServiceImpl implements RouteService{
     }
 
     @Override
-    public List<RouteResponse.RouteResponseDto> getRoute(User user) {
+    public List<RouteResponse> getRoute(User user) {
         userRepository.findByNicknameAndMemberStatusIs(user.getNickname(), User.MemberStatus.ACTIVE)
                 .orElseThrow(()->new GeneralException(Code.DONT_EXIST_USER));
 
@@ -99,7 +99,7 @@ public class RouteServiceImpl implements RouteService{
                     if (!route.getUser().getPublishRoute().equals(PublishStatus.PUBLIC)) {
                         throw new GeneralException(Code.NO_PUBLIC_ROUTE);
                     }
-                    return RouteResponse.RouteResponseDto.builder()
+                    return RouteResponse.builder()
                             .routeId(route.getRouteId())
                             .routeName(route.getRouteName())
                             .numStore(routeListRepository.countRouteListByRoute(route))
@@ -109,7 +109,7 @@ public class RouteServiceImpl implements RouteService{
     }
 
     @Override
-    public List<RouteResponse.RouteResponseDto> getGroupRoute(Long groupId) {
+    public List<RouteResponse> getGroupRoute(Long groupId) {
         // 그룹 존재 여부 확인
         Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
                 .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
@@ -117,7 +117,7 @@ public class RouteServiceImpl implements RouteService{
         //특정 그룹 내 루트 조회
         List<Route> routes = routeRepository.findRoutesByGroupAndStatus(group,BaseEntity.Status.ACTIVE);
         return routes.stream().map(
-                        Route -> RouteResponse.RouteResponseDto.builder()
+                        Route -> RouteResponse.builder()
                                 .routeId(Route.getRouteId())
                                 .routeName(Route.getRouteName())
                                 .numStore(routeListRepository.countRouteListByRoute(Route))

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/UserRepository.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    User findByNickname(String nickname);
 
     Optional<User> findByUserIdAndMemberStatusIs(UUID uuid, User.MemberStatus status);
 

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -42,6 +42,7 @@ public enum Code {
     ROUTE_ORDINAL_BAD_REQUEST(HttpStatus.BAD_REQUEST,403304,"루트 내 이동 경로는 1부터 6까지만 가능합니다"),
     ROUTE_MYROUTE_BAD_REQUEST(HttpStatus.BAD_REQUEST,403305,"내 루트는 최소 1개 이상의 경로를 포함해야 합니다."),
     ROUTELIST_TO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS,403306,"루트 내 상점 항목은 최대 6개까지 가능합니다."),
+    NO_PUBLIC_ROUTE(HttpStatus.FORBIDDEN,403307,"해당 루트는 비공개 상태입니다."),
 
     //Group 관련 에러 +4
     FIND_FAIL_GROUP(HttpStatus.NOT_FOUND, 404401, "존재하지 않는 그룹입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 :루트 내 경로 항목 삭제 시 자동으로 순서 조정
- [x] 버그 수정 : 루트 수정 시 만약 루트명만 입력하면 리스트 미 작성 시 NullPointerException 발생
- [x] 리펙토링 : 리뷰 정보가 없을 때 반환 값이 통일되면서 동일 메서드 사용으로 수정, API 경로 주석 작성, 아직 남아있던 이너 클래스 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- PUBLIC_REVIWE 컬럼 반영하기 위해 리뷰 정보 가져오는 로직 통일수정
- 원활한 차후 관리를 위해 API 경로 주석 작성
- 통일성 부여를 위해 아직 남아있던 이너 클래스 수정

- 루트 수정 시 수정할 항목만 입력 받도록 하기 위해서는 routeList가 빈 배열 형태 유지가 필수적인데 이를 입력 시 front 처리에서 수정할 항목만 받을 수 있도록 Beckend에서 처리하도록 함

### 작업 내역

- 프론트엔드 요청 사항에 따라 루트 내 항목 삭제 시 이동 순서를 자동으로 조절하도록 수정
- 루트 수정 시 만약 루트명만 입력하면 리스트 미 작성 시 NullPointerException 발생을 막기 위해 setter 추가

### 특이 사항
- DTO에 setter가 추가되었는데  front에서 처리하지 않으면서도 setter가 없을 수 있는 List.size() null 관련 다른 방안을 알고 계시다면 조언해주세요

### Issue Number 
close: #116 

