### PR TITLE
fix: 피드 상세 보기 API에서 리뷰의 해시태그가 없을 때 상세보기 에러가 발생하는 부분 해결 & 프론트에서 편하게 List로 해시태그 id값 반환

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/FeedDetailResponse.java
@@ -21,7 +21,7 @@ public class FeedDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String menuName;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    String hashTags;
+    List<Long> hashTags;
     Integer taste;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer spiciness;
@@ -34,7 +34,7 @@ public class FeedDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String comment;
 
-    public static FeedDetailResponse of(Review review, String hashTags, boolean likeCheck){
+    public static FeedDetailResponse of(Review review, List<Long> hashTags, boolean likeCheck){
         return FeedDetailResponse.builder()
                 .storeId(review.getStore().getStoreId())
                 .storeName(review.getStore().getStoreName())

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -58,14 +58,14 @@ public class FeedServiceImpl implements FeedService{
             throw new PrivateItemException(Code.NO_PUBLIC_REVIEW);
         }
 
-        StringBuilder hashTags = new StringBuilder();
-        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(o-> hashTags.append(o).append(","));
-        //마지막 문자 , 제거
-        hashTags.deleteCharAt(hashTags.length()-1);
+        List<Long> hashTags = new ArrayList<>();
+        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(hashTags::add);
 
         //이 리뷰를 보는 유저가 해당 리뷰를 좋아요했는지 체크
         boolean likeCheck = likedRepository.existsByUserAndReview(user, review);
 
-        return FeedDetailResponse.of(review, hashTags.toString(), likeCheck);
+        //리뷰에 해시태그가 없다면 response에 해시태그 없이 반환
+        if(hashTags.isEmpty()) return FeedDetailResponse.of(review, null, likeCheck);
+        return FeedDetailResponse.of(review, hashTags, likeCheck);
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 피드 상세 보기 API에서 리뷰의 해시태그가 없을 때 상세보기 에러 발생
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
 - 피드 상세 보기 API에서 리뷰의 해시태그가 없을 때 상세보기 에러가 발생했습니다. 해시태그가 없는데 length()-1을 했습니다.
 - 프론트에서 처리하기 쉽게 해시태그를 List로 반환합니다.  

### 작업 내역
해시태그를 List로 반환하도록 하여 length()-1을 하지 않도록 변경되었습니다. 

### Issue Number 
#172 
