### PR TITLE
refactor : 가게 상세 조회 시 카테고리 categoryString을 조회

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreDetailResponse.java
@@ -16,7 +16,7 @@ public class GetStoreDetailResponse{
     @JsonInclude(JsonInclude.Include.NON_NULL)
     Long pinId;
     Long storeId;
-    String categoryName;
+    String categoryString;
     String storeName;
     String address;
     Boolean pin;        // 찜 여부

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -74,8 +74,8 @@ public class StoreServiceImpl implements StoreService{
     public GetStoreDetailResponse getStoreDetail(User user, Long storeId, Long reviewId, Pageable pageable) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
-        Category category = storeRepository.findCategoryByStoreId(storeId)
-                .orElseThrow(() -> new GeneralException(Code.CATEGORY_NOT_FOUND));
+//        Category category = storeRepository.findCategoryByStoreId(storeId)
+//                .orElseThrow(() -> new GeneralException(Code.CATEGORY_NOT_FOUND));
         Long pinId = pinRepository.findByUserAndStoreStoreId(user, storeId);
 
         List<Review> top4Reviews = reviewRepository.findFirst4ByStoreOrderByLikedDesc(store);
@@ -120,7 +120,7 @@ public class StoreServiceImpl implements StoreService{
         return GetStoreDetailResponse.builder()
                 .pinId(pinId)
                 .storeId(storeId)
-                .categoryName(category.getCategoryName())
+                .categoryString(store.getCategoryString())
                 .storeName(store.getStoreName())
                 .address(store.getAddress())
                 .reviewImg4(reviewImg)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 : 
- [ ] 버그 수정 :
- [x] 리펙토링 : 가게 상세 조회 시 category를 조회하는 로직 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- store의 category 값을 store엔티티에서 사용하게 되어 이와 같이 수정합니다.

### 작업 후 기대 동작(스크린샷)

- 가게 상세 조회
<img width="586" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/7ed7b760-8f3e-4f2d-9347-a169a2bf8370">


### PR 특이 사항

- 이와 동일한 로직이 있는 @yujiyea @Jeonghee-Han 두분 수정이 필요합니다!

### Issue Number 

close: #180

