### PR TITLE
refactor : 리뷰 조회 시 status을 거치도록 수정 / 방문 날짜를 기준으로 리뷰 조회

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -16,15 +16,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC LIMIT 1")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC'AND r.store = :store ORDER BY r.liked DESC LIMIT 1")
     Optional<Review> findFirstByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
     List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
     List<Review> findFirst4ByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.reviewId DESC")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.reviewId DESC")
     List<Review> findFirstReviewsByStore(Store store, Pageable pageable);
-    @Query("SELECT r FROM Review r WHERE r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.reviewId < :reviewId ORDER BY r.reviewId DESC")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.reviewId < :reviewId ORDER BY r.reviewId DESC")
     List<Review> findReviewsAfterIdByStore(Store store, Long reviewId, Pageable pageable);
     boolean existsByReviewIdAndUser(Long reviewId, User user);
     Integer countByStoreAndUserNickname(Store store, String nickname);      // 방문횟수는 리뷰 공개여부과 상관 X

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -22,10 +22,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
     List<Review> findFirst4ByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.reviewId DESC")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.visitedAt DESC, r.reviewId DESC")
     List<Review> findFirstReviewsByStore(Store store, Pageable pageable);
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.reviewId < :reviewId ORDER BY r.reviewId DESC")
-    List<Review> findReviewsAfterIdByStore(Store store, Long reviewId, Pageable pageable);
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.visitedAt <= :visitedAt AND r.reviewId < :reviewId ORDER BY r.visitedAt DESC, r.reviewId DESC")
+    List<Review> findReviewsAfterIdByStore(Store store, LocalDate visitedAt, Long reviewId, Pageable pageable);
     boolean existsByReviewIdAndUser(Long reviewId, User user);
     @Query("SELECT count(r.reviewId) FROM Review r WHERE r.status = 'ACTIVE' AND r.store = :store AND r.user.nickname = :nickname")
     Integer countByStoreAndUserNickname(Store store, String nickname);      // 방문횟수는 리뷰 공개여부과 상관 X

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -27,7 +27,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store AND r.reviewId < :reviewId ORDER BY r.reviewId DESC")
     List<Review> findReviewsAfterIdByStore(Store store, Long reviewId, Pageable pageable);
     boolean existsByReviewIdAndUser(Long reviewId, User user);
+    @Query("SELECT count(r.reviewId) FROM Review r WHERE r.status = 'ACTIVE' AND r.store = :store AND r.user.nickname = :nickname")
     Integer countByStoreAndUserNickname(Store store, String nickname);      // 방문횟수는 리뷰 공개여부과 상관 X
+    @Query("SELECT count(r.reviewId) FROM Review r WHERE r.status = 'ACTIVE' AND r.store = :store AND r.user = :user")
     Integer countByStoreAndUser(Store store, User user);
     @Query("SELECT r.img1 FROM Review r WHERE r.store.storeId = :storeId ORDER BY r.liked DESC")
     List<String> findTopReviewImageByStoreId(Long storeId);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -6,6 +6,7 @@ import com.umc.gusto.domain.store.service.StoreService;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.auth.model.AuthUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -45,12 +47,13 @@ public class StoreController {
     public ResponseEntity<GetStoreDetailResponse> getStoreDetail(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long storeId,
+            @RequestParam(name = "visitedAt", required = false) LocalDate visitedAt,
             @RequestParam(name = "reviewId", required = false) Long reviewId){
         User user = authUser.getUser();
         Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE);
 
         // 상점 세부 정보 가져오기
-        GetStoreDetailResponse getStoreDetail = storeService.getStoreDetail(user, storeId, reviewId, pageable);
+        GetStoreDetailResponse getStoreDetail = storeService.getStoreDetail(user, storeId, visitedAt, reviewId, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(getStoreDetail);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
@@ -4,13 +4,14 @@ import com.umc.gusto.domain.store.model.response.*;
 import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
 public interface StoreService {
 
     GetStoreResponse getStore(User user, Long storeId);
-    GetStoreDetailResponse getStoreDetail(User user, Long storeId, Long reviewId, Pageable pageable);
+    GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId, Pageable pageable);
     List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId);
     List<GetPinStoreResponse> getPinStoresByCategoryAndLocation(User user, Long myCategoryId, String townName);
     List<GetStoreInfoResponse> searchStore(String keyword);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -71,7 +72,7 @@ public class StoreServiceImpl implements StoreService{
 
 
     @Transactional(readOnly = true)
-    public GetStoreDetailResponse getStoreDetail(User user, Long storeId, Long reviewId, Pageable pageable) {
+    public GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId, Pageable pageable) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
         Category category = storeRepository.findCategoryByStoreId(storeId)
@@ -89,9 +90,9 @@ public class StoreServiceImpl implements StoreService{
         int pageNumber = pageable.getPageNumber();
         List<Review> reviews;
 
-        if (reviewId != null) {
+        if (reviewId != null && visitedAt != null) {
             pageSize = PAGE_SIZE;
-            reviews = reviewRepository.findReviewsAfterIdByStore(store, reviewId, PageRequest.of(pageNumber, pageSize));
+            reviews = reviewRepository.findReviewsAfterIdByStore(store, visitedAt, reviewId, PageRequest.of(pageNumber, pageSize));
         } else {
             pageSize = PAGE_SIZE_FIRST;
             reviews = reviewRepository.findFirstReviewsByStore(store, PageRequest.of(pageNumber, pageSize));


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 리뷰 조회 시 status가 ACTIVE인 경우만 조회 / 방문 날짜를 기준으로 리뷰 조회
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 방문 날짜의 경우 현재 날짜가 아닐 수 있기 때문에 visitedAt과 reviewId을 기준으로 최신순 조회를 한다

### 작업 내역

- 리뷰 조회 시 status가 ACTIVE인지 확인하고 처리한다.
- 방문 날짜를 기준으로 리뷰를 조회한다
- 리뷰 페이징 시 visitedAt를 추가 쿼리로 받는다.

### 작업 후 기대 동작(스크린샷)

- 가게 상세 조회
<img width="596" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/d4420942-c13d-4e91-8ba0-41828ac30ccd">


### Issue Number 

close: #184

