### PR TITLE
refactor: response 해시태그 타입을 String이 아닌 List로 변경

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/request/CreateReviewRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/request/CreateReviewRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 public class CreateReviewRequest {
@@ -14,7 +15,7 @@ public class CreateReviewRequest {
     Long storeId;
     LocalDate visitedAt;
     String menuName;
-    String hashTagId;
+    List<Long> hashTagId;
     @NotNull
     @DecimalMin(value = "0", message = "점수가 0보다 작을 수 없습니다.")
     @DecimalMax(value = "5", message = "점수가 5보다 클 수 없습니다.")

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/request/UpdateReviewRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/request/UpdateReviewRequest.java
@@ -6,12 +6,13 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 public class UpdateReviewRequest {
     LocalDate visitedAt;
     String menuName;
-    String hashTagId;
+    List<Long> hashTagId;
     @DecimalMin(value = "0", message = "점수가 0보다 작을 수 없습니다.")
     @DecimalMax(value = "5", message = "점수가 5보다 클 수 없습니다.")
     Integer taste;

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/ReviewDetailResponse.java
@@ -18,7 +18,7 @@ public class ReviewDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String menuName;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    String hashTags;
+    List<Long> hashTags;
     Integer taste;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer spiciness;
@@ -32,7 +32,7 @@ public class ReviewDetailResponse {
     String comment;
     Integer likeCnt;
 
-    public static ReviewDetailResponse of(Review review, String hashTags){
+    public static ReviewDetailResponse of(Review review, List<Long> hashTags){
         return ReviewDetailResponse.builder()
                 .storeId(review.getStore().getStoreId())
                 .storeName(review.getStore().getStoreName())
@@ -40,23 +40,6 @@ public class ReviewDetailResponse {
                 .images(review.getImageList())
                 .menuName(review.getMenuName())
                 .hashTags(hashTags)
-                .taste(review.getTaste())
-                .spiciness(review.getSpiciness())
-                .mood(review.getMood())
-                .toilet(review.getToilet())
-                .parking(review.getParking())
-                .comment(review.getComment())
-                .likeCnt(review.getLiked())
-                .build();
-    }
-
-    public static ReviewDetailResponse of(Review review){
-        return ReviewDetailResponse.builder()
-                .storeId(review.getStore().getStoreId())
-                .storeName(review.getStore().getStoreName())
-                .visitedAt(review.getVisitedAt())
-                .images(review.getImageList())
-                .menuName(review.getMenuName())
                 .taste(review.getTaste())
                 .spiciness(review.getSpiciness())
                 .mood(review.getMood())

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -74,8 +75,7 @@ public class ReviewServiceImpl implements ReviewService{
 
         //리뷰와 해시태그 연결
         if(createReviewRequest.getHashTagId()!=null){
-            String[] hashTags = createReviewRequest.getHashTagId().split(",");
-            connectHashTag(review, hashTags);
+            createReviewRequest.getHashTagId().forEach(hashTag -> connectHashTag(review, hashTag));
         }
 
         reviewRepository.save(review);
@@ -103,8 +103,7 @@ public class ReviewServiceImpl implements ReviewService{
             //기존 해시태그 지우기
             review.getTaggingSet().clear();
             //새로운 해시태그로 생성
-            String[] changeHashTags = updateReviewRequest.getHashTagId().split(",");
-            connectHashTag(review, changeHashTags);
+            updateReviewRequest.getHashTagId().forEach(changeHashTag -> connectHashTag(review, changeHashTag));
         }
         if(updateReviewRequest.getTaste()!=null){
             review.updateTaste(updateReviewRequest.getTaste());
@@ -146,16 +145,12 @@ public class ReviewServiceImpl implements ReviewService{
             throw new PrivateItemException(Code.NO_PUBLIC_REVIEW);
         }
 
-        boolean hashTagEmpty = review.getTaggingSet().isEmpty(); //true면 해시태그 없음
-        if(!hashTagEmpty) {
-            StringBuilder hashTags = new StringBuilder();
-            review.getTaggingSet().stream().map(r -> r.getHashTag().getHasTagId()).forEach(o -> hashTags.append(o).append(","));
-            //마지막 문자 , 제거
-            hashTags.deleteCharAt(hashTags.length() - 1);
-            return ReviewDetailResponse.of(review, hashTags.toString());
-        }else{
-            return ReviewDetailResponse.of(review);
-        }
+        List<Long> hashTags = new ArrayList<>();
+        review.getTaggingSet().stream().map(r-> r.getHashTag().getHasTagId()).forEach(hashTags::add);
+
+        //리뷰에 해시태그가 없다면 response에 해시태그 없이 반환
+        if(hashTags.isEmpty()) ReviewDetailResponse.of(review, null);
+        return ReviewDetailResponse.of(review, hashTags);
     }
 
     @Override
@@ -188,15 +183,13 @@ public class ReviewServiceImpl implements ReviewService{
         reviewRepository.save(review);
     }
 
-    private void connectHashTag(Review review, String[] hashTags){
-        for(String hashTagId : hashTags){
-            HashTag hashTag = hashTagRepository.findById(Long.parseLong(hashTagId)).orElseThrow(()-> new NotFoundException(Code.HASHTAG_NOT_FOUND));
-            Tagging tagging = Tagging.builder()
-                    .hashTag(hashTag)
-                    .review(review)
-                    .build();
-            review.connectHashTag(tagging);
-        }
+    private void connectHashTag(Review review, Long hashTagId){
+        HashTag hashTag = hashTagRepository.findById(hashTagId).orElseThrow(()-> new NotFoundException(Code.HASHTAG_NOT_FOUND));
+        Tagging tagging = Tagging.builder()
+                .hashTag(hashTag)
+                .review(review)
+                .build();
+        review.connectHashTag(tagging);
     }
 
     private void updateImages(List<MultipartFile> images, Review review){


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 : 
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
 - 프론트에서 처리하기 쉽게 해시태그를 List로 반환합니다.  

### 작업 내역
 - 리뷰 1건 조회 API request 변경
 - 리뷰 수정 API request 변경
 - 리뷰 작성 response 변경

### Issue Number 
#190 
