### PR TITLE
refactor: 타인의 루트 조회 API / feat: 정렬 조건 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface GroupListRepository extends JpaRepository<GroupList,Long> {
     Optional<GroupList> findGroupListByGroupListId(Long groupListId);
-    List<GroupList> findGroupListByGroup(Group group);
+    List<GroupList> findGroupListByGroupOrderByCreatedAtDesc(Group group);
     int countGroupListsByGroup(Group group);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -284,7 +284,7 @@ public class GroupServiceImpl implements GroupService{
         Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
                 .orElseThrow(() -> new GeneralException(Code.FIND_FAIL_GROUP));
         // 그룹 내 모든 찜한 상점 조회 = 그룹리스트 조회
-        List<GroupList> groupLists = groupListRepository.findGroupListByGroup(group);
+        List<GroupList> groupLists = groupListRepository.findGroupListByGroupOrderByCreatedAtDesc(group);
 
         // 그룹 리스트에 해당하는 각 상점 정보 조회
         return groupLists.stream().map(gl -> {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -71,7 +71,7 @@ public class RouteController {
 
     /**
      * 루트 수정
-     * /{routeId}
+     * /routes/{routeId}
      */
     @PatchMapping("/{routeId}")
     public ResponseEntity<?> modifyRoute(@PathVariable Long routeId, @RequestBody ModifyRouteRequest request){

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -79,7 +79,15 @@ public class RouteController {
         return ResponseEntity.ok(HttpStatus.OK);
     }
 
-
+    /**
+     * 타인의 루트 조회
+     * [GET] /routes/{nickname}
+     */
+    @GetMapping("/{nickname}")
+    public ResponseEntity<List<RouteResponse>> allUserRoute(@PathVariable String nickname){
+        List<RouteResponse> route = routeService.getRoute(nickname);
+        return ResponseEntity.ok().body(route);
+    }
 
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -69,21 +69,11 @@ public class RouteListController {
     public ResponseEntity<?> getRouteListDetail(
             @PathVariable Long routeId,
             @RequestParam(required = false) Long groupId,
+            @RequestParam(required = false) String nickname,
             @AuthenticationPrincipal AuthUser authUSer
     ){
-        return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,authUSer.getUser(),groupId));
+        return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,authUSer.getUser(),groupId,nickname));
     }
 
-    /**
-     * 타인의 루트 상세 조회
-     * [GET] /routeLists/{routeId}?nickname={nickname}
-     */
-    @GetMapping("/{routeId}")
-    public ResponseEntity<?> getRouteListDetail(
-            @PathVariable Long routeId,
-            @RequestParam String nickname
-    ){
-        return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,nickname));
-    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -69,10 +69,21 @@ public class RouteListController {
     public ResponseEntity<?> getRouteListDetail(
             @PathVariable Long routeId,
             @RequestParam(required = false) Long groupId,
-             @AuthenticationPrincipal AuthUser authUSer
+            @AuthenticationPrincipal AuthUser authUSer
     ){
         return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,authUSer.getUser(),groupId));
     }
 
+    /**
+     * 타인의 루트 상세 조회
+     * [GET] /routeLists/{routeId}?nickname={nickname}
+     */
+    @GetMapping("/{routeId}")
+    public ResponseEntity<?> getRouteListDetail(
+            @PathVariable Long routeId,
+            @RequestParam String nickname
+    ){
+        return ResponseEntity.ok().body(routeListService.getRouteListDetail(routeId,nickname));
+    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface RouteListRepository extends JpaRepository<RouteList,Long> {
     int countRouteListByRoute(Route route);
 
-    List<RouteList> findByRoute(Route route);
+    List<RouteList> findByRouteOrderByOrdinalAsc(Route route); // 이동 순서 기준 정렬
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -25,13 +25,13 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
 
     // 유저의 루트 목록 조회 , 그룹X, ACTIVE
-    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ")
+    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
     List<Route> findRouteByUserAndStatus(@Param("user") User user, @Param("status") BaseEntity.Status status);
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회
-    List<Route> findRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
+    List<Route> findRoutesByGroupAndStatusOrderByCreatedAtDesc(Group group, BaseEntity.Status status);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
@@ -24,9 +24,6 @@ public interface RouteListService {
     List<RouteListResponse> getRouteListDistance(Long routeId);
 
     // 루트 상세 조회
-    RouteRouteListResponse getRouteListDetail(Long routeId, User user, Long groupId);
-
-    // 루트 상세 조회
-    RouteRouteListResponse getRouteListDetail(Long routeId,String nickname);
+    RouteRouteListResponse getRouteListDetail(Long routeId, User user, Long groupId, String nickname);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListService.java
@@ -26,4 +26,7 @@ public interface RouteListService {
     // 루트 상세 조회
     RouteRouteListResponse getRouteListDetail(Long routeId, User user, Long groupId);
 
+    // 루트 상세 조회
+    RouteRouteListResponse getRouteListDetail(Long routeId,String nickname);
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -87,7 +87,7 @@ public class RouteListServiceImpl implements RouteListService{
         Route route = routeRepository.findRouteByRouteIdAndStatus(deleteRouteList.getRoute().getRouteId(), BaseEntity.Status.ACTIVE)
                 .orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
 
-        List<RouteList> routeLists = routeListRepository.findByRoute(route);
+        List<RouteList> routeLists = routeListRepository.findByRouteOrderByOrdinalAsc(route);
         for (RouteList list : routeLists) {
             // 삭제된 아이템의 순서보다 큰 아이템들의 순서를 조정
             if(deleteRouteList.getOrdinal()< list.getOrdinal() && list.getOrdinal() >1)
@@ -100,7 +100,7 @@ public class RouteListServiceImpl implements RouteListService{
     @Override
     public List<RouteListResponse> getRouteListDistance(Long routeId) {
         Route route = routeRepository.findRouteByRouteIdAndStatus(routeId,BaseEntity.Status.ACTIVE).orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
-        List<RouteList> routeList = routeListRepository.findByRoute(route);
+        List<RouteList> routeList = routeListRepository.findByRouteOrderByOrdinalAsc(route);
         return  routeList.stream().map(rL ->
                 RouteListResponse.builder()
                         .longitude(rL.getStore().getLongitude())
@@ -137,7 +137,7 @@ public class RouteListServiceImpl implements RouteListService{
         // 조회 공통 로직
         Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE).orElseThrow(()-> new GeneralException(Code.ROUTE_NOT_FOUND));
 
-        List<RouteList> routeList = routeListRepository.findByRoute(route);
+        List<RouteList> routeList = routeListRepository.findByRouteOrderByOrdinalAsc(route);
         List<RouteListResponse> routeLists = routeList.stream().map(rL ->
                 RouteListResponse.builder()
                         .routeListId(rL.getRouteListId())

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -22,4 +22,7 @@ public interface RouteService {
 
     // 루트 상세 수정
     void modifyRouteList(Long routeId, ModifyRouteRequest request);
+
+    // 타인의 루트 조회
+    List<RouteResponse> getRoute(String nickname);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -94,17 +94,11 @@ public class RouteServiceImpl implements RouteService{
         List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);
 
         return routes.stream()
-                .map(route -> {
-                    // 유저 활성화 설정 변경
-                    if (!route.getUser().getPublishRoute().equals(PublishStatus.PUBLIC)) {
-                        throw new GeneralException(Code.NO_PUBLIC_ROUTE);
-                    }
-                    return RouteResponse.builder()
+                .map(route -> RouteResponse.builder()
                             .routeId(route.getRouteId())
                             .routeName(route.getRouteName())
                             .numStore(routeListRepository.countRouteListByRoute(route))
-                            .build();
-                })
+                            .build())
                 .collect(Collectors.toList());
     }
 
@@ -168,6 +162,28 @@ public class RouteServiceImpl implements RouteService{
                 }
             }
         }
+    }
+
+    @Override
+    public List<RouteResponse> getRoute(String nickname) {
+        User user = userRepository.findByNicknameAndMemberStatusIs(nickname, User.MemberStatus.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
+
+        List<Route> routes = routeRepository.findRouteByUserAndStatus(user, BaseEntity.Status.ACTIVE);
+
+        return routes.stream()
+                .map(route -> {
+                    // 유저 활성화 설정 변경
+                    if (!route.getUser().getPublishRoute().equals(PublishStatus.PUBLIC)) {
+                        throw new GeneralException(Code.NO_PUBLIC_ROUTE);
+                    }
+                    return RouteResponse.builder()
+                            .routeId(route.getRouteId())
+                            .routeName(route.getRouteName())
+                            .numStore(routeListRepository.countRouteListByRoute(route))
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -109,7 +109,7 @@ public class RouteServiceImpl implements RouteService{
                 .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
 
         //특정 그룹 내 루트 조회
-        List<Route> routes = routeRepository.findRoutesByGroupAndStatus(group,BaseEntity.Status.ACTIVE);
+        List<Route> routes = routeRepository.findRoutesByGroupAndStatusOrderByCreatedAtDesc(group,BaseEntity.Status.ACTIVE);
         return routes.stream().map(
                         Route -> RouteResponse.builder()
                                 .routeId(Route.getRouteId())


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 정렬 기준 추가
- [ ] 버그 수정 :
- [x] 리펙토링 :타인의 루트 상세 조회 로직 수정,  타인의 루트 조회 로직 분리
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
-  타인의 루트 조회 시 nickname값을 통해 user 활성화 여부를 먼저 확인하고 이후 루트를 조회하도록 수정 
- API 경로 충돌을 방지하기 위해 RequestParam 값을 통해 nickname 확보로 통일

- 내 루트/ 그룹 루트 목록의 경우 CreateAt기준 최신 순으로 정렬
- 루트리스트의 경우 Ordinal 이동 순서 기준 오름차순으로 정렬

### 작업 내역

- 타인의 루트 조회 분리 
- 루트 최신 순 정렬
- 타인의 루트 상세 조회 유저 활성화 순서- 루트 조회 순서 변경

### 작업 후 기대 동작(스크린샷)

- 타인의 루트 상세 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/83b5d3ba-7a7d-4798-9a7a-08a5398d1895)


- 타인의 루트 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/90f6ce87-1545-427c-852e-9f31603b2c6b)


- 이동 순서 기준 정렬
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/fd3b3709-5a7b-496e-bacc-0e99c1851427)


### PR 특이 사항

- 타인 관련 로직 외에도, 전체적인 정렬이 추가되었습니다.
- 타인 관련 로직과 정렬 로직이 겹치는 RouteRepository코드 변경이 있어 충돌을 방지하고자 하나의 PR로 작성하였습니다

### Issue Number 

close: #188 