### PR TITLE
feat: GroupList 이미 존재하는 가게 추가 시 에러 발생

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
@@ -2,6 +2,7 @@ package com.umc.gusto.domain.group.repository;
 
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.GroupList;
+import com.umc.gusto.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,4 +12,5 @@ public interface GroupListRepository extends JpaRepository<GroupList,Long> {
     Optional<GroupList> findGroupListByGroupListId(Long groupListId);
     List<GroupList> findGroupListByGroup(Group group);
     int countGroupListsByGroup(Group group);
+    Boolean existsGroupListByGroupAndStore(Group group, Store store);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -22,6 +22,7 @@ import com.umc.gusto.domain.group.repository.GroupRepository;
 import com.umc.gusto.domain.review.entity.Review;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
 import com.umc.gusto.domain.route.entity.Route;
+import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.group.repository.InvitationCodeRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
@@ -254,9 +255,16 @@ public class GroupServiceImpl implements GroupService{
         if(!groupMemberRepository.existsGroupMemberByGroupAndUser(group,user))
             throw new GeneralException(Code.USER_NOT_IN_GROUP);
 
+        Store store = storeRepository.findById(request.getStoreId()).orElseThrow(() -> new NotFoundException(Code.STORE_NOT_FOUND));
+
+        //이미 존재하는 상점인지 확인
+        if(groupListRepository.existsGroupListByGroupAndStore(group,store)){
+            throw new GeneralException(Code.ALREADY_ADD_GROUP_LIST);
+        }
+
         GroupList groupList =GroupList.builder()
                 .group(group)
-                .store(storeRepository.findById(request.getStoreId()).orElseThrow(() -> new NotFoundException(Code.STORE_NOT_FOUND)))
+                .store(store)
                 .user(user)
                 .build();
 

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -54,6 +54,7 @@ public enum Code {
     NO_TRANSFER_PERMISSION(HttpStatus.FORBIDDEN, 403407, "그룹 소유자만이 그룹 소유권을 이전할 수 있습니다."),
     GROUPLIST_NOT_FROUND(HttpStatus.NOT_FOUND,403409,"존재하지 않는 그룹 내 상점입니다."),
     ALREADY_JOINED_GROUP(HttpStatus.BAD_REQUEST, 400410, "이미 해당 그룹에 참여한 유저입니다."),
+    ALREADY_ADD_GROUP_LIST(HttpStatus.BAD_REQUEST, 400411,"이미 해당 그룹에 존재하는 그룹리스트입니다."),
   
     //myCategory 관련 에러 +5
     MY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : GroupList 이미 존재하는 가게 추가 시 에러 발생
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경 이유
- 원활한 테스트를 위해  GroupList 이미 존재하는 가게 추가를 허용하고 있었습니다. 그러나 앱 사용성을 고려할 때 중복된 가게 추가를 막는 것이 좋을 것 같아 변경합니다.

### 작업 내역

-  이미 그룹리스트에 추가된 식당을 중복해서 추가하려고 할 경우 이미 존재하는 식당이라는 message를 전달하는 에러처리를 진행했습니다.

### 작업 후 기대 동작(스크린샷)

- 그룹리스트에 이미 존재하는  가게를 추가 시 에러 발생
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/4e1ee628-319a-4c35-8514-03702efdab20)


### Issue Number 

close: #187 
