### PR TITLE
fix: 좋아요한 리뷰는 다시 좋아요할 수 없도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -156,12 +156,16 @@ public class ReviewServiceImpl implements ReviewService{
     @Override
     @Transactional
     public void likeReview(User user, Long reviewId) {
-
         Review review = reviewRepository.findByReviewIdAndStatus(reviewId, BaseEntity.Status.ACTIVE).orElseThrow(()->new NotFoundException(Code.REVIEW_NOT_FOUND));
 
         //본인 리뷰를 좋아요하는지 확인
         if(review.getUser().getUserId().equals(user.getUserId())){ //TODO: .equals로 하는 동등성 비교가 안되서 DB의 @ID를 비교하는 식으로 했으나 비즈니스 키로 equals를 구현해보자.
             throw new GeneralException(Code.NO_ONESELF_LIKE);
+        }
+
+        //이미 리뷰를 했었는지 확인
+        if(likedRepository.existsByUserAndReview(user, review)){
+            throw new GeneralException(Code.ALREADY_LIKED_REVIEW);
         }
 
         review.updateLiked("like");

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -33,6 +33,7 @@ public enum Code {
     NO_PUBLIC_REVIEW(HttpStatus.FORBIDDEN, 403204, "해당 리뷰는 private입니다."),
     NO_ONESELF_LIKE(HttpStatus.BAD_REQUEST, 400204, "자기자신의 리뷰는 좋아요할 수 없습니다."),
     NO_LIKE_REVIEW(HttpStatus.BAD_REQUEST, 400205, "해당 리뷰에 좋아요를 한 적이 없습니다."),
+    ALREADY_LIKED_REVIEW(HttpStatus.BAD_REQUEST, 400206, "이미 좋아요한 리뷰입니다. 좋아요를 클릭할 수 없습니다."),
 
     //Route 관련 에러 +3
     ROUTE_DUPLICATE_ROUTENAME(HttpStatus.CONFLICT, 409301,"이미 사용중인 루트명입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 하나의 리뷰에 여러 번 좋아요 하는 버그
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
현재 하나의 리뷰에 여러 번 좋아요 하는 버그를 발견했습니다.  좋아요한 리뷰인지 체크하는 로직을 추가해서 한번만 좋아요할 수 있도록 수정하였습니다. 

### Issue Number 
#201 
