### PR TITLE
refactor : 이미 찜한 가게 중복 찜 불가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
@@ -31,7 +31,7 @@ public class PinServiceImpl implements PinService{
         Store store = storeRepository.findById(createPin.getStoreId())
                         .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
 
-        // 해당 사용자가 이미 해당 카테고리에서 해당 가게를 찜했는지 확인합니다.
+        // 해당 사용자가 이미 해당 가게를 찜했는지 확인합니다.
         boolean existingPin = pinRepository.existsByUserAndStoreStoreId(user, store.getStoreId());
 
         if (existingPin) {

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/PinServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,8 +28,16 @@ public class PinServiceImpl implements PinService{
     public CreatePinResponse createPin(User user, Long myCategoryId, CreatePinRequest createPin) {
         MyCategory myCategory = myCategoryRepository.findByUserAndMyCategoryId(user, myCategoryId)
                 .orElseThrow(() -> new GeneralException(Code.MYCATEGORY_NOT_FOUND));
+
         Store store = storeRepository.findById(createPin.getStoreId())
                         .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND));
+
+        // 해당 사용자가 이미 해당 카테고리에서 해당 가게를 찜했는지 확인합니다.
+        boolean existingPin = pinRepository.existsByUserAndStoreStoreId(user, store.getStoreId());
+
+        if (existingPin) {
+            throw new GeneralException(Code.PIN_ALREADY_EXISTS);
+        }
 
         Pin pin = Pin.builder()
                 .user(user)

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -56,6 +56,7 @@ public enum Code {
     //myCategory 관련 에러 +5
     MYCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),
     PIN_NOT_FOUND(HttpStatus.NOT_FOUND, 404502,"존재하지 않는 찜 입니다"),
+    PIN_ALREADY_EXISTS(HttpStatus.CONFLICT, 409502, "이미 해당 가게를 찜했습니다"),
     MYCATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, 409501, "이미 존재하는 카테고리입니다."),
     USER_NO_PERMISSION_FOR_MYCATEGORY(HttpStatus.FORBIDDEN, 403501, "해당 유저는 해당 카테고리에 대한 권한이 없습니다."),
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 이미 찜한 가게 중복 찜 불가
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이미 찜한 가게 중복 찜 불가능하게 합니다.(프론트에서 그럴 상황이 없을 것으로 생각돼 추가하지 않았으나 충돌이 날 수 있으니 대처를 위해 해당 기능을 추가합니다.)
- 가게는 하나의 카테고리에 대해서만 찜할 수 있으므로 카테고리는 상관 없이 가게가 찜이 된 것인지 여부만 확인합니다.


### 작업 후 기대 동작(스크린샷)

- 찜하기
<img width="598" alt="스크린샷 2024-02-18 184251" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/584e44ff-8bb7-4e80-83af-02a4f6da9f4f">


### Issue Number 

close: #204
