### PR TITLE
refactor: 가게 카테고리 참조를 categoryString으로 변경

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreInfoResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreInfoResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GetStoreInfoResponse {
     Long storeId;
-    String categoryName;
+    String categoryString;
     String storeName;
     String address;
     String reviewImg;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -173,7 +173,7 @@ public class StoreServiceImpl implements StoreService{
 
             GetStoreInfoResponse getStoreInfoResponse = GetStoreInfoResponse.builder()
                     .storeId(store.getStoreId())
-                    .categoryName(store.getCategory().getCategoryName())
+                    .categoryString(store.getCategoryString())
                     .storeName(store.getStoreName())
                     .address(store.getAddress())
                     .reviewImg(reviewImg)
@@ -219,7 +219,7 @@ public class StoreServiceImpl implements StoreService{
                     return GetStoreInfoResponse.builder()
                             .storeId(result.getStoreId())
                             .storeName(result.getStoreName())
-                            .categoryName(result.getCategoryString())
+                            .categoryString(result.getCategoryString())
                             .address(result.getAddress())
                             .reviewImg(reviewImg)
                             .build();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 가게 카테고리 참조를 categoryString으로 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- store의 category 값을 store엔티티에서 사용


### 작업 후 기대 동작(스크린샷)

- 현재 지역의 찜한 식당 방문 여부 조회 
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/b42865a2-4c9a-4667-b258-8ce08251c242)


### Issue Number 

close: #210 
