### PR TITLE
refactor: 리뷰 생성 API에서 리뷰 건너뛰기 상황도 대응할 수 있도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/entity/Review.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/entity/Review.java
@@ -52,6 +52,9 @@ public class Review extends BaseEntity {
     private String comment;
 
     @Builder.Default
+    private boolean skipCheck = false;
+
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "publishReview", nullable = false, length = 10)
     private PublishStatus publishReview = PublishStatus.PUBLIC;

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/request/CreateReviewRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/request/CreateReviewRequest.java
@@ -11,12 +11,13 @@ import java.util.List;
 
 @Getter
 public class CreateReviewRequest {
+    @NotNull(message = "리뷰 건너뛰기인지 체크해야 합니다.")
+    boolean skipCheck;
     @NotNull(message = "storeId는 null일 수 없습니다.")
     Long storeId;
     LocalDate visitedAt;
     String menuName;
     List<Long> hashTagId;
-    @NotNull
     @DecimalMin(value = "0", message = "점수가 0보다 작을 수 없습니다.")
     @DecimalMax(value = "5", message = "점수가 5보다 클 수 없습니다.")
     Integer taste;

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -41,16 +41,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByUserAndStatusAndVisitedAtBetween(User user, BaseEntity.Status status, LocalDate startDate, LocalDate lastDate);
 
     boolean existsByUserAndReviewIdLessThan(User user, Long reviewId);
-    @Query(value = "SELECT * FROM review r WHERE r.user_id <> :user AND r.status = 'ACTIVE' ORDER BY RAND() limit 15", nativeQuery = true)
+    @Query(value = "SELECT * FROM review r WHERE r.user_id <> :user AND r.status = 'ACTIVE' AND r.skip_check=false ORDER BY RAND() limit 15", nativeQuery = true)
     List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);
 
     //검색 기능
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.skipCheck = false AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")
     List<Review> searchByStoreContains(String keyword); //TODO: 후에 페이징 처리 하기
-    @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.store.storeName like concat('%', :keyword, '%') AND t.hashTag.hasTagId = :hashTagId")
+    @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.skipCheck=false AND t.review.store.storeName like concat('%', :keyword, '%') AND t.hashTag.hasTagId = :hashTagId")
     List<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId);
-    @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.hashTag.hasTagId = :hashTagId")
+    @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.skipCheck=false AND t.hashTag.hasTagId = :hashTagId")
     List<Review> searchByHashTagContains(Long hashTagId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -53,6 +53,7 @@ public class ReviewServiceImpl implements ReviewService{
 
         //리뷰 생성
         Review review = Review.builder()
+                .skipCheck(createReviewRequest.isSkipCheck())
                 .store(store)
                 .user(user)
                 .visitedAt(createReviewRequest.getVisitedAt())

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,13 +51,16 @@ public class ReviewServiceImpl implements ReviewService{
     @Override
     public void createReview(User user, List<MultipartFile> images, CreateReviewRequest createReviewRequest) {
         Store store= storeRepository.findById(createReviewRequest.getStoreId()).orElseThrow(()-> new NotFoundException(Code.STORE_NOT_FOUND));
-
+        LocalDate visitedAt = createReviewRequest.getVisitedAt();
+        if(createReviewRequest.getVisitedAt()==null){
+            visitedAt = LocalDate.now();
+        }
         //리뷰 생성
         Review review = Review.builder()
                 .skipCheck(createReviewRequest.isSkipCheck())
                 .store(store)
                 .user(user)
-                .visitedAt(createReviewRequest.getVisitedAt())
+                .visitedAt(visitedAt)
                 .menuName(createReviewRequest.getMenuName())
                 .taste(createReviewRequest.getTaste())
                 .spiciness(createReviewRequest.getSpiciness())


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 리뷰 생성 API에서 리뷰 건너뛰기 상황도 대응할 수 있도록 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
리뷰 건너뛰기를 하게 되면 방문날짜, 디폴트 이미지, 가게가 포함된 리뷰가 생성되어야 합니다. 또한, 건너뛰기한 리뷰는 먹스또 피드에 보이면 안됩니다.
그래서 건너뛰기한 리뷰인지 체크하는 컬럼을 추가하고 먹스또 피드에는 건너뛰기한 리뷰가 나오지 않도록 수정합니다. 

### Issue Number 
#212
