### PR TITLE
fix: 팔로워 리스트 조회 시 본인을 return하지 않도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -340,8 +340,8 @@ public class UserServiceImpl implements UserService{
                 .map(follow -> {
                     FollowResponse item = FollowResponse.builder()
                             .followId(follow.getFollowId())
-                            .nickname(follow.getFollowing().getNickname())
-                            .profileImg(follow.getFollowing().getProfileImage())
+                            .nickname(follow.getFollower().getNickname())
+                            .profileImg(follow.getFollower().getProfileImage())
                             .build();
 
                     return item;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 팔로워 리스트 조회 시 팔로워 정보가 아닌 본인의 정보가 return되는 문제
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 팔로워 리스트 조회 시 팔로워 정보가 아닌 본인의 정보가 return되는 문제

### 작업 내역

- 잘못된 필드를 참조하고 있었습니다 (`follower`를 참조해야하나 `following`를 참조)

### PR 특이 사항

- develop 브랜치로는 추가 PR 없이 commit push 예정입니다.
