### PR TITLE
fix : 가게 조회 시 이미지가 한 가게 리뷰 이미지만 보이는 현상 해결

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -17,11 +17,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC'AND r.store = :store ORDER BY r.liked DESC LIMIT 1")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC LIMIT 1")
     Optional<Review> findFirstByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC, r.reviewId DESC LIMIT 3")
     List<Review> findFirst3ByStoreOrderByLikedDesc(Store store);
-    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
+    @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.liked DESC, r.reviewId DESC LIMIT 4")
     List<Review> findFirst4ByStoreOrderByLikedDesc(Store store);
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.user.publishReview = 'PUBLIC' AND r.store = :store ORDER BY r.visitedAt DESC, r.reviewId DESC")
     List<Review> findFirstReviewsByStore(Store store, Pageable pageable);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
@@ -10,10 +10,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
-    @Query("SELECT oh FROM OpeningHours oh WHERE oh.store.storeId = :storeId")
-    Optional<OpeningHours> findOpeningHoursByStoreId(Long storeId);
-    @Query("SELECT s.category FROM Store s WHERE s.storeId = :storeId")
-    Optional<Category> findCategoryByStoreId(Long storeId);
     @Query("SELECT s FROM Store s WHERE s.town.townName = :townName AND s.storeId IN :storeIds")
     List<Store> findByTownNameAndStoreIds(String townName, List<Long> storeIds);
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 가게 조히 시 이미지가 한 가게 리뷰 이미지만 보이는 현상
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 가게 조회 시 이미지가 한 가게 리뷰 이미지만 보이는 현상이 있어서 메서드 쿼리문을 변경했습니다.

