### PR TITLE
refactor: 랜덤 피드, 검색 엔진 API 결과 개수 제한하기

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -48,9 +48,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     //검색 기능
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.skipCheck = false AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")
-    List<Review> searchByStoreContains(String keyword); //TODO: 후에 페이징 처리 하기
+    List<Review> searchByStoreContains(String keyword, PageRequest pageRequest); //TODO: 후에 페이징 처리 하기
     @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.skipCheck=false AND t.review.store.storeName like concat('%', :keyword, '%') AND t.hashTag.hasTagId = :hashTagId")
-    List<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId);
+    List<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId, PageRequest pageRequest);
     @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.skipCheck=false AND t.hashTag.hasTagId = :hashTagId")
-    List<Review> searchByHashTagContains(Long hashTagId);
+    List<Review> searchByHashTagContains(Long hashTagId, PageRequest pageRequest);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -41,7 +41,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByUserAndStatusAndVisitedAtBetween(User user, BaseEntity.Status status, LocalDate startDate, LocalDate lastDate);
 
     boolean existsByUserAndReviewIdLessThan(User user, Long reviewId);
-    @Query(value = "SELECT * FROM review r WHERE r.user_id <> :user AND r.status = 'ACTIVE' AND r.skip_check=false ORDER BY RAND() limit 15", nativeQuery = true)
+    @Query(value = "SELECT * FROM review r WHERE r.user_id <> :user AND r.status = 'ACTIVE' AND r.skip_check=false ORDER BY RAND() limit 33", nativeQuery = true)
     List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -11,6 +11,7 @@ import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.customException.NotFoundException;
 import com.umc.gusto.global.exception.customException.PrivateItemException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -32,16 +33,17 @@ public class FeedServiceImpl implements FeedService{
     @Override
     public SearchFeedResponse searchFeed(String keyword, List<Long> hashTags) {
         List<Review> searchResult = new ArrayList<>();
+        PageRequest pageRequest = PageRequest.of(0,33);
         //맛집과 해시태그를 함께 검색하는 경우
         if(keyword!=null && hashTags!=null){
             for(Long hashTagId: hashTags){
-                searchResult.addAll(reviewRepository.searchByStoreAndHashTagContains(keyword, hashTagId));
+                searchResult.addAll(reviewRepository.searchByStoreAndHashTagContains(keyword, hashTagId, pageRequest));
             }
         } else if(keyword!=null){ //맛집을 검색하는 경우
-            searchResult = reviewRepository.searchByStoreContains(keyword);
+            searchResult = reviewRepository.searchByStoreContains(keyword, pageRequest);
         } else if(hashTags!=null){
             for(Long hashTagId: hashTags){
-                searchResult.addAll(reviewRepository.searchByHashTagContains(hashTagId));
+                searchResult.addAll(reviewRepository.searchByHashTagContains(hashTagId, pageRequest));
             }
         }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
@@ -1,17 +1,14 @@
 package com.umc.gusto.domain.store.repository;
 
-import com.umc.gusto.domain.store.entity.Category;
-import com.umc.gusto.domain.store.entity.OpeningHours;
 import com.umc.gusto.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("SELECT s FROM Store s WHERE s.town.townName = :townName AND s.storeId IN :storeIds")
     List<Store> findByTownNameAndStoreIds(String townName, List<Long> storeIds);
 
-    List<Store> findByStoreNameContains(String keyword);
+    List<Store> findTop5ByStoreNameContains(String keyword);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -210,7 +210,7 @@ public class StoreServiceImpl implements StoreService{
 
     @Override
     public List<GetStoreInfoResponse> searchStore(String keyword) {
-        List<Store> searchResult = storeRepository.findByStoreNameContains(keyword);
+        List<Store> searchResult = storeRepository.findTop5ByStoreNameContains(keyword);
 
         return searchResult.stream()
                 .map(result -> {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 랜덤피드, 검색 엔진 API 결과 개수를 제한합니다. 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
데모데이에서는 5, 33개만 필요하기 때문에 랜덤피드와 피드 검색엔진은 33개, 가게 검색엔진 결과는 3개로 변경합니다. 

### Issue Number 
#226
