### PR TITLE
refactor : 현재 지역의 카테고리 별 찜한 가게 목록 방문여부 필터링 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -45,6 +45,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);
+    boolean existsByStore(Store store);
 
     //검색 기능
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.skipCheck = false AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -59,16 +59,18 @@ public class StoreController {
 
     /**
      * 현 지역의 카테고리 별 찜한 가게 목록 조회
-     * [GET] /stores/map?townName={townName}&myCategoryId={myCategoryId}
+     * [GET] /stores/map?townName={townName}&myCategoryId={myCategoryId}&visited={visitStatus}
      */
     @GetMapping("/map")
     public ResponseEntity<List<GetStoresInMapResponse>> getStoresInMap(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(name = "townName") String townName,
-            @RequestParam(name = "myCategoryId", required = false) Long myCategoryId) {
+            @RequestParam(name = "myCategoryId", required = false) Long myCategoryId,
+            @RequestParam(name = "visited", required = false) Boolean visited
+            ) {
 
         User user = authUser.getUser();
-        List<GetStoresInMapResponse> getStoresInMaps = storeService.getStoresInMap(user, townName, myCategoryId);
+        List<GetStoresInMapResponse> getStoresInMaps = storeService.getStoresInMap(user, townName, myCategoryId, visited);
         return  ResponseEntity.status(HttpStatus.OK).body(getStoresInMaps);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
@@ -12,7 +12,7 @@ public interface StoreService {
 
     GetStoreResponse getStore(User user, Long storeId);
     GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId, Pageable pageable);
-    List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId);
+    List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId, Boolean visited);
     List<GetPinStoreResponse> getPinStoresByCategoryAndLocation(User user, Long myCategoryId, String townName);
     List<GetStoreInfoResponse> searchStore(String keyword);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -140,7 +140,7 @@ public class StoreServiceImpl implements StoreService{
         List<Store> visitedStatus = new ArrayList<>();
         for (Pin pin : pins) {
             Store store = pin.getStore();
-            boolean hasVisited = reviewRepository.existsByStore(store);
+            boolean hasVisited = reviewRepository.existsByStoreAndUserNickname(store, user.getNickname());
             if (visited) {
                 if (hasVisited) {
                     visitedStatus.add(store);

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -132,8 +132,6 @@ public class StoreServiceImpl implements StoreService{
 
     @Transactional(readOnly = true)
     public List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId, Boolean visited) {
-        List<Store> stores;
-
         List<Pin> pins = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
         if (myCategoryId == null) {
             pins = pinRepository.findPinsByUserAndTownNameAndPinIdDESC(user, townName);
@@ -155,9 +153,7 @@ public class StoreServiceImpl implements StoreService{
 
         }
 
-        stores = new ArrayList<>(visitedStatus);
-        
-        return stores.stream()
+        return visitedStatus.stream()
                 .map(store -> GetStoresInMapResponse.builder()
                         .storeId(store.getStoreId())
                         .storeName(store.getStoreName())
@@ -165,7 +161,6 @@ public class StoreServiceImpl implements StoreService{
                         .latitude(store.getLatitude())
                         .build())
                 .collect(Collectors.toList());
-
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 현재 지역의 카테고리 별 찜한 가게 목록 조회 시 방문 여부 필터링
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 데모데이 이후에 하기로 한 방문여부 조회 기능을 추가했습니다.

### 작업 내역
* 방문여부는 해당 가게에 리뷰를 작성했는지를 통해 확인한다.
*  visit 쿼리를 엔드포인트에 추가하고 true, false인 boolean 값을 받는다.

### 작업 후 기대 동작(스크린샷)
<img width="587" alt="image" src="https://github.com/gusto-umc/Gusto-Server/assets/102590823/4081fa7d-62e4-4391-ada7-5ef293fcb839">

### Issue Number 

close: #229

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
* 데모데이 이후 추가 수정사항 pr입니다.
* getStoreInMap 메서드에서 findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC에서 USER 값에 대한 필터링이 존재하여 처음에는 existByStore만 사용해 방문횟수를 확인했습니다. 그런데 조회 시 user 값에 대한 필터링 없이 조회가 되던군요. 그래서 existByStoreAndUserNickname을 사용해 user 처리를 두번했습니다. 희랑도 방문조회 시 user을 두번 필터링을 거치던데 혹시 왜 그런지 궁금합니다.