### PR TITLE
fix: 팔로워 목록 / 팔로잉 목록의 페이징/정렬 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
@@ -14,9 +14,9 @@ import java.util.UUID;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
 
-    @Query("SELECT f FROM Follow f WHERE f.follower = :follower AND f.followId > :followId ORDER BY f.createdAt DESC")
+    @Query("SELECT f FROM Follow f WHERE f.follower = :follower AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
     List<Follow> findFollowList(@Param("follower") User follower, @Param("followId") Long followId, Pageable pageable);
 
-    @Query("SELECT f FROM Follow f WHERE f.following = :following AND f.followId > :followId ORDER BY f.createdAt DESC")
+    @Query("SELECT f FROM Follow f WHERE f.following = :following AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
     List<Follow> findFollwerList(@Param("following") User following, @Param("followId") Long followId, Pageable pageable);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
@@ -17,6 +17,12 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Query("SELECT f FROM Follow f WHERE f.follower = :follower AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
     List<Follow> findFollowList(@Param("follower") User follower, @Param("followId") Long followId, Pageable pageable);
 
+    @Query("SELECT f FROM Follow f WHERE f.follower = :follower ORDER BY f.createdAt DESC, f.followId DESC")
+    List<Follow> findFollowList(@Param("follower") User follower, Pageable pageable);
+
     @Query("SELECT f FROM Follow f WHERE f.following = :following AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
     List<Follow> findFollwerList(@Param("following") User following, @Param("followId") Long followId, Pageable pageable);
+
+    @Query("SELECT f FROM Follow f WHERE f.following = :following ORDER BY f.createdAt DESC, f.followId DESC")
+    List<Follow> findFollwerList(@Param("following") User following, Pageable pageable);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -293,12 +293,13 @@ public class UserServiceImpl implements UserService{
     @Override
     @Transactional
     public List<FollowResponse> getFollowList(User user, Long followId) {
-        if(followId == null) {
-            followId = 0L;
-        }
+        List<Follow> followList;
 
-        //follow 목록 조회
-        List<Follow> followList = followRepository.findFollowList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        if(followId == null) {
+            followList = followRepository.findFollowList(user, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        } else {
+            followList = followRepository.findFollowList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        }
 
         // 반환할 목록이 없음 throw Exception
         if(followList.size() == 0) {
@@ -324,11 +325,13 @@ public class UserServiceImpl implements UserService{
     @Override
     @Transactional
     public List<FollowResponse> getFollwerList(User user, Long followId) {
-        if(followId == null) {
-            followId = 0L;
-        }
+        List<Follow> followList;
 
-        List<Follow> followList = followRepository.findFollwerList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        if(followId == null) {
+            followList = followRepository.findFollwerList(user, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        } else {
+            followList = followRepository.findFollwerList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
+        }
 
         // 반환할 목록이 없음 throw Exception
         if(followList.size() == 0) {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 :  팔로워/팔로잉 목록의 페이징/정렬 수정

### 변경사항 및 이유

- 팔로워/팔로잉 목록 반환 시 정렬이 깨져있었고,
페이징 처리를 위한 선택 기준이 잘못되어 페이징 오류가 발생하였습니다.

### 작업 내역

- 정렬 기준을 추가하였으며, 설계대로 페이징이 작동할 수 있도록 수정하였습니다.
