### PR TITLE
feat: 내/타인의/그룹의 루트 페이징 기능: 루트 커서 기반으로 다음 루트 전달

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -73,7 +73,7 @@ public class GroupController {
     }
 
     /**
-     * 그룹리스트 추가
+     * 그룹리스트 추가 = 그룹에서 찜
      * [POST] /groups/{groupId}/groupList
      */
     @PostMapping("/{groupId}/groupList")

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -53,9 +53,10 @@ public class RouteController {
      */
     @GetMapping("")
     public ResponseEntity<List<RouteResponse>> allMyRoute(
-            @AuthenticationPrincipal AuthUser authUSer
+            @AuthenticationPrincipal AuthUser authUSer,
+            @RequestParam(required = false, name = "routeId") Long routeId
     ){
-        List<RouteResponse> route = routeService.getRoute(authUSer.getUser());
+        List<RouteResponse> route = routeService.getRoute(authUSer.getUser(),routeId);
         return ResponseEntity.ok().body(route);
     }
 
@@ -64,8 +65,9 @@ public class RouteController {
      * [GET] /routes/groups{groupId}
      */
     @GetMapping("/groups/{groupId}")
-    public ResponseEntity<List<RouteResponse>> allMyRoute(@PathVariable Long groupId){
-        List<RouteResponse> route = routeService.getGroupRoute(groupId);
+    public ResponseEntity<List<RouteResponse>> allMyRoute(
+            @PathVariable Long groupId, @RequestParam(required = false, name = "routeId") Long routeId){
+        List<RouteResponse> route = routeService.getGroupRoute(groupId, routeId);
         return ResponseEntity.ok().body(route);
     }
 
@@ -84,8 +86,11 @@ public class RouteController {
      * [GET] /routes/{nickname}
      */
     @GetMapping("/{nickname}")
-    public ResponseEntity<List<RouteResponse>> allUserRoute(@PathVariable String nickname){
-        List<RouteResponse> route = routeService.getRoute(nickname);
+    public ResponseEntity<List<RouteResponse>> allUserRoute
+    (@PathVariable String nickname,
+     @RequestParam(required = false, name = "routeId") Long routeId
+     ){
+        List<RouteResponse> route = routeService.getRoute(nickname,routeId);
         return ResponseEntity.ok().body(route);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -4,6 +4,7 @@ import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,14 +25,18 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     @Query("SELECT r FROM Route r WHERE r.routeId = :routeId AND r.status = :status AND r.group.groupId IS NULL")
     Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
 
-    // 유저의 루트 목록 조회 , 그룹X, ACTIVE
+    // 가장 첫 페이징
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    List<Route> findRouteByUserAndStatus(@Param("user") User user, @Param("status") BaseEntity.Status status);
+    List<Route> findRouteByUserFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
+
+    // 유저의 루트 목록 조회 , 그룹X, ACTIVE
+    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    List<Route> findRouteByAfterIRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회
-    List<Route> findRoutesByGroupAndStatusOrderByCreatedAtDesc(Group group, BaseEntity.Status status);
-
+    @Query("select r from Route r where r.group =:group AND r.status =:status AND r.routeId >:routeId ")
+    List<Route> findRoutesByGroup(@Param("group") Group group, @Param("routeId") Long routeId ,@Param("status") BaseEntity.Status status, Pageable pageable);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -15,14 +15,14 @@ public interface RouteService {
     void deleteRoute(Long routeId,User user);
 
     // 내 루트 조회
-    List<RouteResponse> getRoute(User user);
+    List<RouteResponse> getRoute(User user, Long routeId);
 
     // 그룹 내 루트 조회
-    List<RouteResponse> getGroupRoute(Long groupId );
+    List<RouteResponse> getGroupRoute(Long groupId,Long routeId);
 
     // 루트 상세 수정
     void modifyRouteList(Long routeId, ModifyRouteRequest request);
 
     // 타인의 루트 조회
-    List<RouteResponse> getRoute(String nickname);
+    List<RouteResponse> getRoute(String nickname, Long routeId);
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 페이징 작업
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 내/타인의 루트 : 초기값 6개,생성시점을 기준으로 내림차순 정렬, 가장 마지막 routeId값을 기준으로 다음 값부터 6개씩 출력
- 그룹의 루트 : 초기값 6개, 가장 마지막의  routeId값을 기준으로 다음 값부터 6개씩 출력, 

### 작업 후 기대 동작(스크린샷)

- 내/타인의 루트 
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/fa242f3b-6cdc-448b-8125-dce07a2ad850)
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/dcc88aab-5715-4146-b230-01068ba77f1b)

- 그룹의 루트
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/f95ca72f-ce49-4e9d-8d8b-b2f3c750f2f9)
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/f603800c-29b6-4c85-b098-8e370d452ccd)


### Issue Number 

close: #231 