### PR TITLE
feat: 소셜 로그인 2.0

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -30,23 +30,20 @@ public class UserController {
     /**
      * 회원 가입 API
      * [POST] /users/sing-up
-     * @param token
      * @param multipartFile
      * @param signUpRequest
      * @return -
      */
     @PostMapping("/sign-up")
-    public ResponseEntity signUp(@RequestHeader("Temp-Token") String token,
-                         @RequestPart(name = "profileImg", required = false) MultipartFile multipartFile,
+    public ResponseEntity signUp(@RequestPart(name = "profileImg", required = false) MultipartFile multipartFile,
                          @RequestPart(name = "info") SignUpRequest signUpRequest) {
-        // 에러 핸들러 작업 예정으로 try-catch 작성하지 않음
-        Tokens tokens = userService.createUser(token, multipartFile, signUpRequest);
+        Tokens tokens = userService.createUser(multipartFile, signUpRequest);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("X-Auth-Token", tokens.getAccessToken());
         headers.set("refresh-token", tokens.getRefreshToken());
 
-        return ResponseEntity.ok()
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .headers(headers)
                 .build();
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -2,13 +2,11 @@ package com.umc.gusto.domain.user.controller;
 
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
+import com.umc.gusto.domain.user.model.request.SignInRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
-import com.umc.gusto.domain.user.model.response.ProfileResponse;
-import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
+import com.umc.gusto.domain.user.model.response.*;
 import com.umc.gusto.domain.user.service.UserService;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
-import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
-import com.umc.gusto.domain.user.model.response.FollowResponse;
 import com.umc.gusto.global.auth.model.AuthUser;
 import com.umc.gusto.global.auth.model.Tokens;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +27,7 @@ public class UserController {
 
     /**
      * 회원 가입 API
-     * [POST] /users/sing-up
+     * [POST] /users/sign-up
      * @param multipartFile
      * @param signUpRequest
      * @return -
@@ -46,6 +44,20 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .headers(headers)
                 .build();
+    }
+
+    /**
+     * 기본 닉네임 생성 API
+     * [GET] /users/random-nickname
+     * @param -
+     * @return String
+     */
+    @PostMapping("/random-nickname")
+    public ResponseEntity generateNickname() {
+        NicknameResponse nicknameResponse = userService.generateRandomNickname();
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(nicknameResponse);
     }
 
     /**
@@ -73,6 +85,25 @@ public class UserController {
         userService.confirmNickname(nickname);
 
         return ResponseEntity.ok()
+                .build();
+    }
+
+    /**
+     * 로그인 API
+     * [POST] /users/sign-in
+     * @param signInRequest
+     * @return -
+     */
+    @PostMapping("/sign-up")
+    public ResponseEntity signUp(@RequestBody SignInRequest signInRequest) {
+        Tokens tokens = userService.signIn(signInRequest);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Auth-Token", tokens.getAccessToken());
+        headers.set("refresh-token", tokens.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
                 .build();
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/entity/Social.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/entity/Social.java
@@ -25,14 +25,11 @@ public class Social extends BaseTime {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 15)
-    private SocialStatus socialStatus = SocialStatus.WAITING_SIGN_UP;
+    private SocialStatus socialStatus = SocialStatus.CONNECTED;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
-
-    @Column(columnDefinition = "BINARY(16)")
-    private UUID temporalToken;
 
     @Column
     private String providerId;

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/request/SignInRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/request/SignInRequest.java
@@ -1,0 +1,11 @@
+package com.umc.gusto.domain.user.model.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignInRequest {
+    String provider;
+    String providerId;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/request/SignUpRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/request/SignUpRequest.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SignUpRequest {
+    String provider;
+    String providerId;
     String nickname;
     String age;
     String gender;

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/NicknameResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/NicknameResponse.java
@@ -1,0 +1,12 @@
+package com.umc.gusto.domain.user.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@Setter
+public class NicknameResponse {
+    String nickname;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/SocialRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/SocialRepository.java
@@ -4,10 +4,7 @@ import com.umc.gusto.domain.user.entity.Social;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public interface SocialRepository extends JpaRepository<Social, Long> {
     Optional<Social> findBySocialTypeAndProviderId(Social.SocialType socialType, String providerId);
-
-    Optional<Social> findByTemporalToken(UUID tempToken);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -2,12 +2,10 @@ package com.umc.gusto.domain.user.service;
 
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.model.request.PublishingInfoRequest;
+import com.umc.gusto.domain.user.model.request.SignInRequest;
 import com.umc.gusto.domain.user.model.request.SignUpRequest;
 import com.umc.gusto.domain.user.model.request.UpdateProfileRequest;
-import com.umc.gusto.domain.user.model.response.FeedProfileResponse;
-import com.umc.gusto.domain.user.model.response.ProfileResponse;
-import com.umc.gusto.domain.user.model.response.PublishingInfoResponse;
-import com.umc.gusto.domain.user.model.response.FollowResponse;
+import com.umc.gusto.domain.user.model.response.*;
 import com.umc.gusto.global.auth.model.Tokens;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,7 +23,9 @@ public interface UserService {
     void confirmNickname(String nickname);
 
     // 닉네임 랜덤 생성
-    String generateRandomNickname();
+    NicknameResponse generateRandomNickname();
+
+    Tokens signIn(SignInRequest signInRequest);
 
     // 먹스또 프로필 조회
     FeedProfileResponse getProfile(User user, String nickname);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -16,7 +16,7 @@ import java.util.List;
 public interface UserService {
     
     // 회원 가입
-    Tokens createUser(String tempToken, MultipartFile multipartFile, SignUpRequest signUpRequest);
+    Tokens createUser(MultipartFile multipartFile, SignUpRequest signUpRequest);
 
     // 닉네임 중복 체크
     void checkNickname(String nickname);

--- a/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
@@ -47,7 +47,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
             OAuthAttributes attributes = oAuth2User.getOAuthAttributes();
             String uri = UriComponentsBuilder.fromUriString(redirectUrl + "/new-user")
-                    .queryParam("temp-token", String.valueOf(socialInfo.getTemporalToken()))
+//                    .queryParam("temp-token", String.valueOf(socialInfo.getTemporalToken()))
                     .queryParam("nickname", attributes.getNickname())
                     .queryParam("profileImg", attributes.getProfileImg())
                     .queryParam("gender", attributes.getGender().name())

--- a/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
@@ -46,7 +46,7 @@ public class OAuthService extends DefaultOAuth2UserService {
                      .socialType(provider)
                      .providerId(oAuthAttributes.getId())
                      .socialStatus(Social.SocialStatus.WAITING_SIGN_UP)
-                     .temporalToken(UUID.randomUUID())
+//                     .temporalToken(UUID.randomUUID())
                      .build());
 
              if(oAuthAttributes.getNickname() == null) {

--- a/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/OAuthService.java
@@ -50,7 +50,7 @@ public class OAuthService extends DefaultOAuth2UserService {
                      .build());
 
              if(oAuthAttributes.getNickname() == null) {
-                 oAuthAttributes.updateNickname(userService.generateRandomNickname());
+                 oAuthAttributes.updateNickname(userService.generateRandomNickname().getNickname());
              }
 
              if(oAuthAttributes.getProfileImg() == null) {

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -20,6 +20,7 @@ public enum Code {
     USER_FOLLOW_ALREADY(HttpStatus.CONFLICT, 409002, "이미 팔로우했습니다."),
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
     USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
+    USER_NOT_OUR_CLIENT(HttpStatus.NOT_FOUND, 404004, "가입 정보가 존재하지 않습니다."),
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 변경된 소셜 로그인 방법 반영
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 소셜로그인 인증 주체가 서버 -> 안드로이드 로 변경되어, 관련하여 내용을 수정하였습니다.
- `Social` Entity의 `temporalToken` 필드가 삭제되었습니다. 사용하시는 DB와 일치시켜주시길 바랍니다!
- `Social` Entity의 `socialStatus` 필드의 default 값이 변경되었습니다만, DB에는 영향을 미치지 않습니다.

### Issue Number 

close: #10 #49 
