### PR TITLE
refactor: 그룹 페이징 로직 개선 / 가게 반환값 개수를 10개로 제한

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -16,6 +16,7 @@ import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.auth.model.AuthUser;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.*;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -157,12 +160,12 @@ public class GroupController {
      * [GET] /groups?lastGroupId={lastGroupId}
      */
     @GetMapping
-    public ResponseEntity<Page<GetGroupsResponse>> getGroups(@AuthenticationPrincipal AuthUser authUser,
-                                                             @RequestParam(name = "lastGroupId", required = false) Long lastGroupId,
-                                                             @RequestParam(name = "size", defaultValue = "5") int size)
+    public ResponseEntity<Map<String, Object>> getGroups(@AuthenticationPrincipal AuthUser authUser,
+                                                         @RequestParam(name = "lastGroupId", required = false) Long lastGroupId,
+                                                         @RequestParam(name = "size", defaultValue = "5") int size)
     {
         User user = authUser.getUser();
-        Page<GetGroupsResponse> getGroups = groupService.getUserGroups(user, lastGroupId, size);
+        Map<String, Object> getGroups = groupService.getUserGroups(user, lastGroupId, size);
         return ResponseEntity.status(HttpStatus.OK).body(getGroups);
     }
 
@@ -171,10 +174,10 @@ public class GroupController {
      * [GET] /groups/{groupId}/members?lastMemberId={lastMemberId}
      */
     @GetMapping("/{groupId}/members")
-    public ResponseEntity<Page<GetGroupMemberResponse>> getGroupMembers (@PathVariable Long groupId,
+    public ResponseEntity<Map<String, Object>> getGroupMembers (@PathVariable Long groupId,
                                                                          @RequestParam(name = "lastMemberId", required = false) Long lastMemberId,
                                                                          @RequestParam(name = "size", defaultValue = "10") int size){
-        Page<GetGroupMemberResponse> getGroupMembers = groupService.getGroupMembers(groupId, lastMemberId, size);
+        Map<String, Object> getGroupMembers = groupService.getGroupMembers(groupId, lastMemberId, size);
         return ResponseEntity.status(HttpStatus.OK).body(getGroupMembers);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -5,29 +5,22 @@ import com.umc.gusto.domain.group.model.request.JoinGroupRequest;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.TransferOwnershipRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
-import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
 import com.umc.gusto.domain.group.model.response.GroupListResponse;
 import com.umc.gusto.domain.group.model.response.GetInvitationCodeResponse;
 import com.umc.gusto.domain.group.model.response.TransferOwnershipResponse;
-import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.auth.model.AuthUser;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.data.domain.*;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -13,10 +13,13 @@ import com.umc.gusto.domain.group.model.response.TransferOwnershipResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.user.entity.User;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public interface GroupService {
     // 그룹 생성
@@ -53,10 +56,10 @@ public interface GroupService {
     void leaveGroup(User user, Long groupId);
 
     // 그룹 목록 조회
-    Page<GetGroupsResponse> getUserGroups(User user, Long lastGroupId, int size);
+    Map<String, Object> getUserGroups(User user, Long lastGroupId, int size);
 
     //그룹 구성원 조회
-    Page<GetGroupMemberResponse> getGroupMembers(Long groupId, Long lastMemberId, int size);
+    Map<String, Object> getGroupMembers(Long groupId, Long lastMemberId, int size);
 
     //그룹 루트 삭제
     void deleteRoute(Long routeId, User user, Long groupId);

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -5,21 +5,15 @@ import com.umc.gusto.domain.group.model.request.JoinGroupRequest;
 import com.umc.gusto.domain.group.model.request.PostGroupRequest;
 import com.umc.gusto.domain.group.model.request.TransferOwnershipRequest;
 import com.umc.gusto.domain.group.model.request.UpdateGroupRequest;
-import com.umc.gusto.domain.group.model.response.GetGroupMemberResponse;
 import com.umc.gusto.domain.group.model.response.GetGroupResponse;
 import com.umc.gusto.domain.group.model.response.GroupListResponse;
 import com.umc.gusto.domain.group.model.response.GetInvitationCodeResponse;
 import com.umc.gusto.domain.group.model.response.TransferOwnershipResponse;
-import com.umc.gusto.domain.group.model.response.GetGroupsResponse;
 import com.umc.gusto.domain.group.model.response.UpdateGroupResponse;
 import com.umc.gusto.domain.user.entity.User;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public interface GroupService {
     // 그룹 생성

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -33,7 +33,6 @@ import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
 import com.umc.gusto.global.exception.customException.NotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -198,13 +198,13 @@ public class StoreServiceImpl implements StoreService{
         // 방문하지 않은 가게 리스트
         UnvisitedStoresResponse unvisitedStoresResponse = UnvisitedStoresResponse.builder()
                 .numPinStores(unvisitedStoresInfo.size())
-                .unvisitedStores(unvisitedStoresInfo)
+                .unvisitedStores(unvisitedStoresInfo.size() > 3 ? unvisitedStoresInfo.subList(0, 10) : unvisitedStoresInfo)
                 .build();
 
         // 방문한 가게 리스트
         VisitedStoresResponse visitedStoresResponse = VisitedStoresResponse.builder()
                 .numPinStores(visitedStoresInfo.size())
-                .visitedStores(visitedStoresInfo)
+                .visitedStores(visitedStoresInfo.size() > 3 ? visitedStoresInfo.subList(0, 10) : visitedStoresInfo)
                 .build();
 
         GetPinStoreResponse pinStoreResponse = GetPinStoreResponse.builder()

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -4,7 +4,6 @@ import com.umc.gusto.domain.myCategory.entity.Pin;
 import com.umc.gusto.domain.myCategory.repository.PinRepository;
 import com.umc.gusto.domain.review.entity.Review;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
-import com.umc.gusto.domain.store.entity.Category;
 import com.umc.gusto.domain.store.entity.OpeningHours;
 import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.model.response.*;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -197,13 +197,13 @@ public class StoreServiceImpl implements StoreService{
         // 방문하지 않은 가게 리스트
         UnvisitedStoresResponse unvisitedStoresResponse = UnvisitedStoresResponse.builder()
                 .numPinStores(unvisitedStoresInfo.size())
-                .unvisitedStores(unvisitedStoresInfo.size() > 3 ? unvisitedStoresInfo.subList(0, 10) : unvisitedStoresInfo)
+                .unvisitedStores(unvisitedStoresInfo.size() > 10 ? unvisitedStoresInfo.subList(0, 10) : unvisitedStoresInfo)
                 .build();
 
         // 방문한 가게 리스트
         VisitedStoresResponse visitedStoresResponse = VisitedStoresResponse.builder()
                 .numPinStores(visitedStoresInfo.size())
-                .visitedStores(visitedStoresInfo.size() > 3 ? visitedStoresInfo.subList(0, 10) : visitedStoresInfo)
+                .visitedStores(visitedStoresInfo.size() > 10 ? visitedStoresInfo.subList(0, 10) : visitedStoresInfo)
                 .build();
 
         GetPinStoreResponse pinStoreResponse = GetPinStoreResponse.builder()


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 그룹 페이징 로직 개선 / 가게 반환값 개수를 10개로 제한
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 그룹 페이징 처리 시, 메타데이터가 아닌 hasNext 변수만 반환하도록 수정
- 방문 여부에 따른 가게 목록을 각각 최대 10개 반환하도록 수정

### 작업 후 기대 동작(스크린샷)

- 그룹 목록 조회

![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/68879d62-b485-4be7-a661-4ed24f7a70be)

- 그룹 구성원 조회 (현재 그룹 구성원이 3명인 상황)

![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/921e4f0b-d45e-4e31-b0c9-af8e1709c777)


### Issue Number 

close: #234 #247