### PR TITLE
feat: 팔로워/팔로잉 목록 조회 시 hasNext 여부를 반환

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -17,8 +17,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -236,12 +234,12 @@ public class UserController {
      * @return List<>
      */
     @GetMapping("/following")
-    public ResponseEntity<List<FollowResponse>> followList(@AuthenticationPrincipal AuthUser authUser,
+    public ResponseEntity<PagingResponse> followList(@AuthenticationPrincipal AuthUser authUser,
                                                            @RequestParam(required = false, name = "followId") Long followId) {
-        List<FollowResponse> followResponses = userService.getFollowList(authUser.getUser(), followId);
+        PagingResponse pagingResponse = userService.getFollowList(authUser.getUser(), followId);
 
         return ResponseEntity.ok()
-                .body(followResponses);
+                .body(pagingResponse);
     }
 
     /**
@@ -251,11 +249,11 @@ public class UserController {
      * @return List<>
      */
     @GetMapping("/follower")
-    public ResponseEntity<List<FollowResponse>> followerList(@AuthenticationPrincipal AuthUser authUser,
+    public ResponseEntity<PagingResponse> followerList(@AuthenticationPrincipal AuthUser authUser,
                                                            @RequestParam(required = false, name = "followId") Long followId) {
-        List<FollowResponse> followResponses = userService.getFollwerList(authUser.getUser(), followId);
+        PagingResponse pagingResponse = userService.getFollwerList(authUser.getUser(), followId);
 
         return ResponseEntity.ok()
-                .body(followResponses);
+                .body(pagingResponse);
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/response/PagingResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/response/PagingResponse.java
@@ -1,0 +1,15 @@
+package com.umc.gusto.domain.user.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class PagingResponse {
+    private boolean hasNext;
+    private List<?> result;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/FollowRepository.java
@@ -2,27 +2,26 @@ package com.umc.gusto.domain.user.repository;
 
 import com.umc.gusto.domain.user.entity.Follow;
 import com.umc.gusto.domain.user.entity.User;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
 
     @Query("SELECT f FROM Follow f WHERE f.follower = :follower AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
-    List<Follow> findFollowList(@Param("follower") User follower, @Param("followId") Long followId, Pageable pageable);
+    Page<Follow> findFollowList(@Param("follower") User follower, @Param("followId") Long followId, Pageable pageable);
 
     @Query("SELECT f FROM Follow f WHERE f.follower = :follower ORDER BY f.createdAt DESC, f.followId DESC")
-    List<Follow> findFollowList(@Param("follower") User follower, Pageable pageable);
+    Page<Follow> findFollowList(@Param("follower") User follower, Pageable pageable);
 
     @Query("SELECT f FROM Follow f WHERE f.following = :following AND f.followId < :followId ORDER BY f.createdAt DESC, f.followId DESC")
-    List<Follow> findFollwerList(@Param("following") User following, @Param("followId") Long followId, Pageable pageable);
+    Page<Follow> findFollwerList(@Param("following") User following, @Param("followId") Long followId, Pageable pageable);
 
     @Query("SELECT f FROM Follow f WHERE f.following = :following ORDER BY f.createdAt DESC, f.followId DESC")
-    List<Follow> findFollwerList(@Param("following") User following, Pageable pageable);
+    Page<Follow> findFollwerList(@Param("following") User following, Pageable pageable);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -9,8 +9,6 @@ import com.umc.gusto.domain.user.model.response.*;
 import com.umc.gusto.global.auth.model.Tokens;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 public interface UserService {
     
     // 회원 가입
@@ -52,8 +50,8 @@ public interface UserService {
     void unfollowUser(User user, String nickname);
 
     // 팔로우 목록
-    List<FollowResponse> getFollowList(User user, Long followId);
+    PagingResponse getFollowList(User user, Long followId);
 
     // 팔로워 목록
-    List<FollowResponse> getFollwerList(User user, Long followId);
+    PagingResponse getFollwerList(User user, Long followId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ import com.umc.gusto.global.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -307,8 +308,8 @@ public class UserServiceImpl implements UserService{
 
     @Override
     @Transactional
-    public List<FollowResponse> getFollowList(User user, Long followId) {
-        List<Follow> followList;
+    public PagingResponse getFollowList(User user, Long followId) {
+        Page<Follow> followList;
 
         if(followId == null) {
             followList = followRepository.findFollowList(user, Pageable.ofSize(FOLLOW_LIST_PAGE));
@@ -316,13 +317,13 @@ public class UserServiceImpl implements UserService{
             followList = followRepository.findFollowList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
         }
 
-        // 반환할 목록이 없음 throw Exception
-        if(followList.size() == 0) {
-            throw new NotFoundException(Code.USER_FOLLOW_NO_MORE_CONTENT);
+        // page가 존재하지 않으면 throw Exception
+        if(followList.isEmpty()) {
+            throw new NotFoundException(Code.USER_FOLLOW_NOT_EXIST);
         }
 
         // res mapping
-        List<FollowResponse> response = followList.stream()
+        List<FollowResponse> result = followList.stream()
                 .map(follow -> {
                     FollowResponse item = FollowResponse.builder()
                             .followId(follow.getFollowId())
@@ -334,13 +335,16 @@ public class UserServiceImpl implements UserService{
                 })
                 .collect(Collectors.toList());
 
-        return response;
+        return PagingResponse.builder()
+                .hasNext(followList.hasNext())
+                .result(result)
+                .build();
     }
 
     @Override
     @Transactional
-    public List<FollowResponse> getFollwerList(User user, Long followId) {
-        List<Follow> followList;
+    public PagingResponse getFollwerList(User user, Long followId) {
+        Page<Follow> followList;
 
         if(followId == null) {
             followList = followRepository.findFollwerList(user, Pageable.ofSize(FOLLOW_LIST_PAGE));
@@ -348,13 +352,13 @@ public class UserServiceImpl implements UserService{
             followList = followRepository.findFollwerList(user, followId, Pageable.ofSize(FOLLOW_LIST_PAGE));
         }
 
-        // 반환할 목록이 없음 throw Exception
-        if(followList.size() == 0) {
-            throw new NotFoundException(Code.USER_FOLLOW_NO_MORE_CONTENT);
+        // page가 존재하지 않으면 throw Exception
+        if(followList.isEmpty()) {
+            throw new NotFoundException(Code.USER_FOLLOWER_NOT_EXIST);
         }
 
         // res mapping
-        List<FollowResponse> response = followList.stream()
+        List<FollowResponse> result = followList.stream()
                 .map(follow -> {
                     FollowResponse item = FollowResponse.builder()
                             .followId(follow.getFollowId())
@@ -366,6 +370,9 @@ public class UserServiceImpl implements UserService{
                 })
                 .collect(Collectors.toList());
 
-        return response;
+        return PagingResponse.builder()
+                .hasNext(followList.hasNext())
+                .result(result)
+                .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -12,18 +12,17 @@ public enum Code {
     NO_PERMISSION(HttpStatus.FORBIDDEN,403, "해당 권한이 없습니다."),
 
     //User 관련 에러 +0
-    USER_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, 409001, "이미 사용중인 닉네임입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404001, "존재하지 않는 유저입니다."),
-    USER_ALREADY_SIGNUP(HttpStatus.CONFLICT, 409003, "가입이 완료된 유저입니다."),
-    USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, 404002, "팔로우한 유저가 아닙니다."),
-    USER_FOLLOW_NO_MORE_CONTENT(HttpStatus.NOT_FOUND, 404003, "리스트가 더이상 존재하지 않습니다."),
-    USER_FOLLOW_ALREADY(HttpStatus.CONFLICT, 409002, "이미 팔로우했습니다."),
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
     USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404001, "존재하지 않는 유저입니다."),
+    USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, 404002, "팔로우한 유저가 아닙니다."),
+    USER_FOLLOW_NO_MORE_CONTENT(HttpStatus.NOT_FOUND, 404003, "리스트가 더이상 존재하지 않습니다."),
     USER_NOT_OUR_CLIENT(HttpStatus.NOT_FOUND, 404004, "가입 정보가 존재하지 않습니다."),
     USER_FOLLOWER_NOT_EXIST(HttpStatus.NOT_FOUND, 404005, "팔로워가 존재하지 않습니다."),
     USER_FOLLOW_NOT_EXIST(HttpStatus.NOT_FOUND, 404006, "팔로우한 유저가 없습니다."),
-
+    USER_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, 409001, "이미 사용중인 닉네임입니다."),
+    USER_FOLLOW_ALREADY(HttpStatus.CONFLICT, 409002, "이미 팔로우했습니다."),
+    USER_ALREADY_SIGNUP(HttpStatus.CONFLICT, 409003, "가입이 완료된 유저입니다."),
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -21,6 +21,9 @@ public enum Code {
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
     USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
     USER_NOT_OUR_CLIENT(HttpStatus.NOT_FOUND, 404004, "가입 정보가 존재하지 않습니다."),
+    USER_FOLLOWER_NOT_EXIST(HttpStatus.NOT_FOUND, 404005, "팔로워가 존재하지 않습니다."),
+    USER_FOLLOW_NOT_EXIST(HttpStatus.NOT_FOUND, 404006, "팔로우한 유저가 없습니다."),
+
 
     //Store 관련 에러 +1
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, 404101, "존재하지 않는 가게입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 팔로워/팔로잉 목록 조회 시 hasNext를 반환합니다.
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 서버의 불필요한 호출을 줄이기 위해 hasNext 변수를 추가 반환합니다.

### 작업 내역

- Repository에서 List를 반환하던 Method의 return value를 Page로 변경하였습니다.
- 기존 반환값인 FollowResponse를 PagingResponse로 래핑하여 hasNext 값을 반환할 수 있도록 했습니다.
- Page가 존재하지 않는 경우, 에러를 반환합니다.
(`검색할 컨텐츠가 존재하지 않는 경우` or `이전 hasNext 결과가 false이며 더이상 탐색할 수 있는 페이지가 없는 경우`)

### 작업 후 기대 동작(스크린샷)

- 동작
  - 정상 반환
    ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/6ff79599-0a05-4369-82e3-b821c1326336)
    ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/0902aa9a-793f-4d57-882a-22de1494437b)

  - 검색할 컨텐츠가 존재하지 않는 경우
    - 팔로워 목록 조회
    ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/969f44a6-dec1-4c51-bb58-bf5f56d1695f)
    - 팔로잉 목록 조회
    ![image](https://github.com/gusto-umc/Gusto-Server/assets/90233522/7405b6f2-ea16-40da-bd03-0e44de4e9aaf)
