### PR TITLE
refactor: 리뷰 모아보기 API시 누락되는 데이터가 보일 수 있도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/CollectReviewsResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/CollectReviewsResponse.java
@@ -7,13 +7,15 @@ import java.util.List;
 
 @Builder
 @Getter
-public class CollectReviewsOfInstaResponse {
-    List<BasicViewResponse> reviews;
+public class CollectReviewsResponse {
+    List<?> reviews;
+    Long cursorId;
     boolean hasNext;
 
-    public static CollectReviewsOfInstaResponse of(List<BasicViewResponse> reviews, boolean hasNext){
-        return CollectReviewsOfInstaResponse.builder()
+    public static CollectReviewsResponse of(List<?> reviews, Long cursorId, boolean hasNext){
+        return CollectReviewsResponse.builder()
                 .reviews(reviews)
+                .cursorId(cursorId)
                 .hasNext(hasNext)
                 .build();
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -32,20 +32,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Integer countByStoreAndUserNickname(Store store, String nickname);      // 방문횟수는 리뷰 공개여부과 상관 X
     @Query("SELECT count(r.reviewId) FROM Review r WHERE r.status = 'ACTIVE' AND r.store = :store AND r.user = :user")
     Integer countByStoreAndUser(Store store, User user);
-    @Query("SELECT r.img1 FROM Review r WHERE r.store.storeId = :storeId ORDER BY r.liked DESC")
-    List<String> findTopReviewImageByStoreId(Long storeId);
 
     Optional<Review> findByReviewIdAndStatus(Long reviewId, BaseEntity.Status status);
     Optional<Page<Review>> findAllByUserAndStatus(User user, BaseEntity.Status status, PageRequest pageRequest);
-    Optional<Page<Review>> findAllByUserAndStatusAndReviewIdLessThan(User user, BaseEntity.Status status, Long reviewId,PageRequest pageRequest);
+    Optional<Page<Review>> findAllByUserAndStatusAndReviewIdLessThanAndVisitedAtLessThanEqual(User user, BaseEntity.Status status, Long reviewId, LocalDate visitedAt,PageRequest pageRequest);
     List<Review> findByUserAndStatusAndVisitedAtBetween(User user, BaseEntity.Status status, LocalDate startDate, LocalDate lastDate);
 
-    boolean existsByUserAndReviewIdLessThan(User user, Long reviewId);
     @Query(value = "SELECT * FROM review r WHERE r.user_id <> :user AND r.status = 'ACTIVE' AND r.skip_check=false ORDER BY RAND() limit 33", nativeQuery = true)
     List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);
-    boolean existsByStore(Store store);
 
     //검색 기능
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.skipCheck = false AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')")

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/CollectReviewService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/CollectReviewService.java
@@ -1,16 +1,15 @@
 package com.umc.gusto.domain.review.service;
 
-import com.umc.gusto.domain.review.model.response.CollectReviewsOfInstaResponse;
+import com.umc.gusto.domain.review.model.response.CollectReviewsResponse;
 import com.umc.gusto.domain.review.model.response.CollectReviewsOfCalResponse;
-import com.umc.gusto.domain.review.model.response.CollectReviewsOfTimelineResponse;
 import com.umc.gusto.domain.user.entity.User;
 
 import java.time.LocalDate;
 
 public interface CollectReviewService {
 //    CollectReviewsOfInstaResponse getReviewOfInstaView(User user, ReviewViewRequest reviewViewRequest);
-    CollectReviewsOfInstaResponse getReviewOfInstaView(User user, Long reviewId, int size);
+    CollectReviewsResponse getReviewOfInstaView(User user, Long reviewId, int size);
     CollectReviewsOfCalResponse getReviewOfCalView(User user, Long reviewId, int size, LocalDate date);
-    CollectReviewsOfTimelineResponse getReviewOfTimeView(User user, Long reviewId, int size);
-    CollectReviewsOfInstaResponse getOthersReview(String nickName, Long reviewId, int size);
+    CollectReviewsResponse getReviewOfTimeView(User user, Long reviewId, int size);
+    CollectReviewsResponse getOthersReview(String nickName, Long reviewId, int size);
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 리뷰 모아보기 API시 누락되는 데이터가 보일 수 있도록 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
리뷰 모아보기는 방문날짜를 기준으로 정렬되어야 한다. 페이징 처리를 하면 ID(PK)값을 기준으로 방문날짜가 항상 내림차순인 것은 아니다. 즉, 커서 ID가 26이고 방문날짜가 4월 10일이지만 리뷰 ID가 27이고 방문날짜가 4월 2일인게 누락된다.

### 작업 내역
- 페이징 처리(정렬된)한 응답값에서 가장 작은 리뷰 ID를 커서 ID로 정하는 것이 아니라 정렬되어 가장 마지막 순서에 있는 리뷰를 커서 ID로 지정한다. 이후, 페이징 처리는 커서 ID보다 작은 리뷰 ID이고 커서 ID의 방문날짜보다 같거나 이전 날짜인 리뷰만 가져오도록 한다.
- 더 이상 리뷰가 없을 때 빈 리스트를 반환하는 경우를 예외처리

### Issue Number 
#250
