### PR TITLE
feat: 초대 코드로 그룹 정보 조회

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -168,6 +168,16 @@ public class GroupController {
     }
 
     /**
+     * 초대 코드로 그룹 정보 조회
+     * [GET] /groups/pre-join
+     */
+    @GetMapping("/pre-join")
+    public ResponseEntity<GetPreJoinGroupInfoResponse> getPreJoinGroupInfo(@RequestBody JoinGroupRequest joinGroupRequest){
+        GetPreJoinGroupInfoResponse getPreJoinGroupInfo = groupService.getPreJoinGroupInfo(joinGroupRequest);
+        return ResponseEntity.status(HttpStatus.OK).body(getPreJoinGroupInfo);
+    }
+
+    /**
      * 그룹 루트 삭제
      * [DELETE] /groups/routes/{routeId}??groupId={groupId}
      */

--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -6,7 +6,6 @@ import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.auth.model.AuthUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetPreJoinGroupInfoResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/model/response/GetPreJoinGroupInfoResponse.java
@@ -1,0 +1,18 @@
+package com.umc.gusto.domain.group.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetPreJoinGroupInfoResponse {
+    String groupName;
+    List<String> groupMembers;
+    int numMembers;
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -48,6 +48,9 @@ public interface GroupService {
     //그룹 구성원 조회
     Map<String, Object> getGroupMembers(Long groupId, Long lastMemberId, int size);
 
+    // 초대 코드로 그룹 정보 조회
+    GetPreJoinGroupInfoResponse getPreJoinGroupInfo(JoinGroupRequest joinGroupRequest);
+
     //그룹 루트 삭제
     void deleteRoute(Long routeId, User user, Long groupId);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -3,7 +3,6 @@ package com.umc.gusto.domain.group.service;
 import com.umc.gusto.domain.group.model.request.*;
 import com.umc.gusto.domain.group.model.response.*;
 import com.umc.gusto.domain.user.entity.User;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Map;

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -282,6 +282,24 @@ public class GroupServiceImpl implements GroupService{
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public GetPreJoinGroupInfoResponse getPreJoinGroupInfo(JoinGroupRequest joinGroupRequest){
+        Group group = groupRepository.findGroupByCodeAndStatus(joinGroupRequest.getCode(), BaseEntity.Status.ACTIVE)
+                .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
+
+        int numMembers = groupMemberRepository.countGroupMembersByGroup(group);
+
+        List<String> groupMembersNickname = groupMemberRepository.findGroupMembersByGroup(group).stream()
+                .map(groupMember -> groupMember.getUser().getNickname())
+                .collect(Collectors.toList());
+
+        return GetPreJoinGroupInfoResponse.builder()
+                .groupName(group.getGroupName())
+                .groupMembers(groupMembersNickname)
+                .numMembers(numMembers)
+                .build();
+    }
+
     @Override
     public void createGroupList(Long groupId,GroupListRequest request,User user) {
         // 그룹 존재 여부 확인


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 초대 코드로 그룹 정보 조회
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 그룹 초대 코드로 그룹에 참여하기 전에 해당 그룹이 맞는지 확인할 수 있도록 하는 추가 API 요청

### 작업 내역

- 초대 코드로 그룹 정보를 조회하는 추가 API 구현

### 작업 후 기대 동작(스크린샷)

- 초대 코드로 그룹 정보 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/134862850/f2b2034e-b3aa-4729-a0fd-13c40a424cbd)


### Issue Number 

close: #261 
