### PR TITLE
feat: sign-out

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -106,6 +106,19 @@ public class UserController {
     }
 
     /**
+     * 로그아웃 API
+     * [POST] /users/sign-out
+     * @param -
+     * @return -
+     */
+    @PostMapping("/sign-out")
+    public ResponseEntity signOut(@AuthenticationPrincipal AuthUser authUser,
+                                  @RequestHeader("refresh-Token") String refreshToken) {
+        return ResponseEntity.status(HttpStatus.RESET_CONTENT)
+                .build();
+    }
+
+    /**
      * 먹스또 프로필 조회
      * [GET] /users/{nickname}/profile
      * @param nickname

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -114,6 +114,8 @@ public class UserController {
     @PostMapping("/sign-out")
     public ResponseEntity signOut(@AuthenticationPrincipal AuthUser authUser,
                                   @RequestHeader("refresh-Token") String refreshToken) {
+        userService.signOut(authUser.getUser(), refreshToken);
+
         return ResponseEntity.status(HttpStatus.RESET_CONTENT)
                 .build();
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -25,6 +25,8 @@ public interface UserService {
 
     Tokens signIn(SignInRequest signInRequest);
 
+    void signOut(User user, String refreshToken);
+
     // 먹스또 프로필 조회
     FeedProfileResponse getProfile(User user, String nickname);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -166,6 +166,11 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
+    public void signOut(User user, String refreshToken) {
+
+    }
+
+    @Override
     public FeedProfileResponse getProfile(User user, String nickname) {
         User target;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -167,7 +167,8 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public void signOut(User user, String refreshToken) {
-
+        jwtService.matchCheckTokens(user.getUserId(), refreshToken);
+        redisService.deleteValues(refreshToken);
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
@@ -124,4 +124,16 @@ public class JwtService implements InitializingBean {
             throw new GeneralException(Code.EXPIRED_REFRESH_TOKEN);
         }
     }
+
+    public void matchCheckTokens(java.util.UUID uuid, String refreshToken) {
+        try {
+            String refreshUuid = (String) getClaims(refreshToken).get(UUID);
+
+            if(!refreshUuid.equals(String.valueOf(uuid))) {
+                throw new GeneralException(Code.NO_MATCH_TOKENS);
+            }
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(Code.EXPIRED_REFRESH_TOKEN);
+        }
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -69,9 +69,10 @@ public enum Code {
 
     // token 관련 에러 +6
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 401601, "유효하지 않은 토큰입니다."),
+    NO_MATCH_TOKENS(HttpStatus.UNAUTHORIZED, 401602, "X-AUTH-TOKEN 정보와 refresh-token 정보가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 401603, "refresh-token이 유효하지 않습니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.FORBIDDEN, 403601, "X-AUTH-TOKEN이 만료되었습니다. 토큰 재발급을 실행해주세요."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, 403602, "refresh-token이 만료되었습니다. 재로그인이 필요합니다"),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, 403602, "refresh-token이 만료되었습니다. 재로그인이 필요합니다."),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 로그아웃 api
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
- 로그아웃 api
  - refresh-token과 access-token을 인자로 받아 로그아웃 처리 합니다.
  - token의 유효성 검사를 한 뒤 Redis에 저장된 토큰 정보를 삭제합니다.