### PR TITLE
refactor: 초대 코드로 그룹 정보 조회 API 엔드포인트를 GET에서 POST로 변경

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -168,9 +168,9 @@ public class GroupController {
 
     /**
      * 초대 코드로 그룹 정보 조회
-     * [GET] /groups/pre-join
+     * [POST] /groups/check-invitation
      */
-    @GetMapping("/pre-join")
+    @PostMapping("/check-invitation")
     public ResponseEntity<GetPreJoinGroupInfoResponse> getPreJoinGroupInfo(@RequestBody JoinGroupRequest joinGroupRequest){
         GetPreJoinGroupInfoResponse getPreJoinGroupInfo = groupService.getPreJoinGroupInfo(joinGroupRequest);
         return ResponseEntity.status(HttpStatus.OK).body(getPreJoinGroupInfo);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 초대 코드로 그룹 정보 조회 API 엔드포인트를 GET에서 POST로 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 초대 코드가 URL에 노출되지 않도록 하기 위해 requestbody사용
- 안드 측에서 GET 메소드 사용 시, requestbody로 요청 불가
- POST 메소드 사용과 동시에 URL에 조회의 목적을 명확히 하기 위해 URL도 수정

### 작업 내역
- 초대 코드로 그룹 정보 조회 API 엔드포인트를 GET에서 POST로 변경
- 목적을 명확히 하기 위해 URL을 /groups/check-invitation으로 수정

### Issue Number 

close: #267
