### PR TITLE
refactor : 찜한 가게 목록 조회 시 카테고리 다중 처리 및 방문 여부 조건 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
@@ -23,5 +23,5 @@ public interface MyCategoryService {
 
     void modifyMyCategory(User user,Long myCategoryId, UpdateMyCategoryRequest request);
 
-    void deleteMyCategories(User user, List<Long> myCategoryId);
+    void deleteMyCategories(User user, List<Long> myCategoryIds);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -50,19 +50,19 @@ public class StoreController {
     }
 
     /**
-     * 현 지역의 카테고리 별 찜한 가게 목록 조회
-     * [GET] /stores/map?townName={townName}&myCategoryId={myCategoryId}&visited={visitStatus}
+     * 현 지역의 카테고리 별 찜한 가게 목록 조회(카테고리 다중 선택 가능)
+     * [GET] /stores/map?townName={townName}&visited={visitStatus}&myCategoryId={myCategoryId}&myCategoryId={myCategoryId}...
      */
     @GetMapping("/map")
     public ResponseEntity<List<GetStoresInMapResponse>> getStoresInMap(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(name = "townName") String townName,
-            @RequestParam(name = "myCategoryId", required = false) Long myCategoryId,
+            @RequestParam(name = "myCategoryId", required = false) List<Long> myCategoryIds,
             @RequestParam(name = "visited", required = false) Boolean visited
             ) {
 
         User user = authUser.getUser();
-        List<GetStoresInMapResponse> getStoresInMaps = storeService.getStoresInMap(user, townName, myCategoryId, visited);
+        List<GetStoresInMapResponse> getStoresInMaps = storeService.getStoresInMap(user, townName, myCategoryIds, visited);
         return  ResponseEntity.status(HttpStatus.OK).body(getStoresInMaps);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GetStoresInMapResponse{
     Long storeId;
-    Long myCategoryId;
     String storeName;
     Double longitude;
     Double latitude;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoresInMapResponse.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GetStoresInMapResponse{
     Long storeId;
+    Long myCategoryId;
     String storeName;
     Double longitude;
     Double latitude;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
@@ -12,7 +12,7 @@ public interface StoreService {
 
     List<GetStoreResponse> getStores(User user, List<Long> storeIds);
     GetStoreDetailResponse getStoreDetail(User user, Long storeId, LocalDate visitedAt, Long reviewId);
-    List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId, Boolean visited);
+    List<GetStoresInMapResponse> getStoresInMap(User user, String townName, List<Long> myCategoryIds, Boolean visited);
     List<GetPinStoreResponse> getPinStoresByCategoryAndLocation(User user, Long myCategoryId, String townName);
     List<GetStoreInfoResponse> searchStore(String keyword);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -145,23 +145,31 @@ public class StoreServiceImpl implements StoreService{
             pins = pinRepository.findPinsByUserAndTownNameAndPinIdDESC(user, townName);
         }
 
-        List<Store> visitedStatus = new ArrayList<>();
-        for (Pin pin : pins) {
-            Store store = pin.getStore();
-            boolean hasVisited = reviewRepository.existsByStoreAndUserNickname(store, user.getNickname());
-            if (visited) {
-                if (hasVisited) {
-                    visitedStatus.add(store);
-                }
-            } else {
-                if (!hasVisited) {
-                    visitedStatus.add(store);
-                }
-            }
+        List<Store> pinStores = new ArrayList<>();
 
+        if (visited == null) {
+            pinStores = pins.stream()
+                    .map(Pin::getStore)
+                    .collect(Collectors.toList());
+
+        } else {
+            for (Pin pin : pins) {
+                Store store = pin.getStore();
+                boolean hasVisited = reviewRepository.existsByStoreAndUserNickname(store, user.getNickname());
+                if (visited) {
+                    if (hasVisited) {
+                        pinStores.add(store);
+                    }
+                } else {
+                    if (!hasVisited) {
+                        pinStores.add(store);
+                    }
+                }
+
+            }
         }
 
-        return visitedStatus.stream()
+        return pinStores.stream()
                 .map(store -> GetStoresInMapResponse.builder()
                         .storeId(store.getStoreId())
                         .storeName(store.getStoreName())

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -139,10 +139,14 @@ public class StoreServiceImpl implements StoreService{
     }
 
     @Transactional(readOnly = true)
-    public List<GetStoresInMapResponse> getStoresInMap(User user, String townName, Long myCategoryId, Boolean visited) {
-        List<Pin> pins = pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName);
-        if (myCategoryId == null) {
+    public List<GetStoresInMapResponse> getStoresInMap(User user, String townName, List<Long> myCategoryIds, Boolean visited) {
+        List<Pin> pins = new ArrayList<>();
+        if (myCategoryIds == null || myCategoryIds.isEmpty()) {
             pins = pinRepository.findPinsByUserAndTownNameAndPinIdDESC(user, townName);
+        } else {
+            for (Long myCategoryId : myCategoryIds) {
+                pins.addAll(pinRepository.findPinsByUserAndMyCategoryIdAndTownNameAndPinIdDESC(user, myCategoryId, townName));
+            }
         }
 
         List<Store> pinStores = new ArrayList<>();

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -106,6 +106,19 @@ public class UserController {
     }
 
     /**
+     * 로그아웃 API
+     * [POST] /users/sign-out
+     * @param -
+     * @return -
+     */
+    @PostMapping("/sign-out")
+    public ResponseEntity signOut(@AuthenticationPrincipal AuthUser authUser,
+                                  @RequestHeader("refresh-Token") String refreshToken) {
+        return ResponseEntity.status(HttpStatus.RESET_CONTENT)
+                .build();
+    }
+
+    /**
      * 먹스또 프로필 조회
      * [GET] /users/{nickname}/profile
      * @param nickname

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -114,6 +114,8 @@ public class UserController {
     @PostMapping("/sign-out")
     public ResponseEntity signOut(@AuthenticationPrincipal AuthUser authUser,
                                   @RequestHeader("refresh-Token") String refreshToken) {
+        userService.signOut(authUser.getUser(), refreshToken);
+
         return ResponseEntity.status(HttpStatus.RESET_CONTENT)
                 .build();
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserService.java
@@ -25,6 +25,8 @@ public interface UserService {
 
     Tokens signIn(SignInRequest signInRequest);
 
+    void signOut(User user, String refreshToken);
+
     // 먹스또 프로필 조회
     FeedProfileResponse getProfile(User user, String nickname);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -166,6 +166,11 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
+    public void signOut(User user, String refreshToken) {
+
+    }
+
+    @Override
     public FeedProfileResponse getProfile(User user, String nickname) {
         User target;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -167,7 +167,8 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public void signOut(User user, String refreshToken) {
-
+        jwtService.matchCheckTokens(user.getUserId(), refreshToken);
+        redisService.deleteValues(refreshToken);
     }
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/JwtService.java
@@ -124,4 +124,16 @@ public class JwtService implements InitializingBean {
             throw new GeneralException(Code.EXPIRED_REFRESH_TOKEN);
         }
     }
+
+    public void matchCheckTokens(java.util.UUID uuid, String refreshToken) {
+        try {
+            String refreshUuid = (String) getClaims(refreshToken).get(UUID);
+
+            if(!refreshUuid.equals(String.valueOf(uuid))) {
+                throw new GeneralException(Code.NO_MATCH_TOKENS);
+            }
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(Code.EXPIRED_REFRESH_TOKEN);
+        }
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -69,9 +69,10 @@ public enum Code {
 
     // token 관련 에러 +6
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 401601, "유효하지 않은 토큰입니다."),
+    NO_MATCH_TOKENS(HttpStatus.UNAUTHORIZED, 401602, "X-AUTH-TOKEN 정보와 refresh-token 정보가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 401603, "refresh-token이 유효하지 않습니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.FORBIDDEN, 403601, "X-AUTH-TOKEN이 만료되었습니다. 토큰 재발급을 실행해주세요."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, 403602, "refresh-token이 만료되었습니다. 재로그인이 필요합니다"),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, 403602, "refresh-token이 만료되었습니다. 재로그인이 필요합니다."),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 찜한 가게 목록 조회 시 카테고리 다중 처리 및 방문 여부 조건 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 프런트의 요청으로 현재 지역의 카테고리 별 찜한 가게 목록 조회 시 카테고리 여러개 처리를 가능하게 하고, 방문 여부에 상관없이 모든 가게를 조회할 수 있도록 한다.

### 작업 내역

- 현재 지역의 카테고리 별 찜한 가게 목록 API에서 다중 카테고리 클릭 가능하게 처리
- 방문 여부에 상관없이 모두 조회 되도록 하는 조건 추가

### 작업 후 기대 동작(스크린샷)

- myCategory 다중 처리
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/2db9fa85-af3c-48e0-9560-083a9d1d8435)
- myCategory 다중 처리 및 방문 여부 값이 없을 때 모든 가게 조회
![image](https://github.com/gusto-umc/Gusto-Server/assets/102590823/f397256b-f072-435b-b4b4-9b05e8ba8734)



### Issue Number 

close: #278