### PR TITLE
Feat: 루트 공개 비공개 여부

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -24,10 +24,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
   
     Boolean existsGroupMemberByGroupAndUser(Group group, User user);
 
-    @Query("SELECT COUNT(gm) " +
+    @Query("SELECT gm.group " +
             "FROM GroupMember gm LEFT JOIN gm.group g " +
             "WHERE g.groupId = :groupId AND gm.user = :user")
-    int existsByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
+    Group findByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
 
     Optional<GroupMember> findGroupMemberByGroupAndGroupMemberId(Group group, Long memberId);
     Optional<GroupMember> findGroupMemberByGroupAndUser(Group group, User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -3,11 +3,12 @@ package com.umc.gusto.domain.group.repository;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.GroupMember;
 import com.umc.gusto.domain.user.entity.User;
-import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -23,11 +24,18 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
   
     Boolean existsGroupMemberByGroupAndUser(Group group, User user);
 
+    @Query("SELECT COUNT(gm) " +
+            "FROM GroupMember gm LEFT JOIN gm.group g " +
+            "WHERE g.groupId = :groupId AND gm.user = :user")
+    int existsByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
+
     Optional<GroupMember> findGroupMemberByGroupAndGroupMemberId(Group group, Long memberId);
     Optional<GroupMember> findGroupMemberByGroupAndUser(Group group, User user);
   
     @Query("SELECT gm.group.groupId FROM GroupMember gm WHERE gm.user = :user")
     List<Long> findGroupIdsByUser(User user);
     int countGroupMembersByGroup(Group group);
+
+
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
@@ -1,7 +1,6 @@
 package com.umc.gusto.domain.group.repository;
 
 import com.umc.gusto.domain.group.entity.Group;
-import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +13,6 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findGroupByGroupIdAndStatus(Long groupId, BaseEntity.Status status);
-
     @Query("SELECT ic.group FROM InvitationCode ic WHERE ic.code = :code AND ic.group.status = :status")
     Optional<Group> findGroupByCodeAndStatus(@Param("code") String code, @Param("status") BaseEntity.Status status);
     @Query("SELECT g FROM Group g WHERE g.groupId IN :groupIds AND g.status = :status ORDER BY g.groupId DESC")

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -106,5 +106,18 @@ public class RouteController {
         return ResponseEntity.ok().body(route);
     }
 
+    /**
+     * 루트별 공개/비공개 설정
+     * [PATCH] /routes/{routeId}/publishing/{publishStatus}
+     */
+    @PatchMapping("/{routeId}/publishing/{publishStatus}")
+    public ResponseEntity modifyPublishingRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long routeId,
+            @PathVariable boolean publishStatus)
+    {
+        routeService.modifyPublishingInfo(authUser.getUser(),routeId,publishStatus);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -102,7 +102,7 @@ public class RouteController {
     (@PathVariable String nickname,
      @RequestParam(required = false, name = "routeId") Long routeId
      ){
-        RoutePagingResponse route = routeService.getRoute(nickname,routeId);
+        RoutePagingResponse route = routeService.getOtherRoute(nickname,routeId);
         return ResponseEntity.ok().body(route);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -9,10 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequestMapping("routes")
 @RequiredArgsConstructor
 public class RouteController {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -32,6 +32,21 @@ public class RouteController {
     }
 
     /**
+     * 그룹 내 루트 추가
+     * [POST] /routes/{groupId}
+     */
+    // 루트 생성
+    @PostMapping("{groupId}")
+    public ResponseEntity<?> createRoute(
+            @PathVariable Long groupId,
+            @RequestBody RouteRequest request,
+            @AuthenticationPrincipal AuthUser authUSer)
+    {
+        routeService.createRouteGroup(groupId,request,authUSer.getUser());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
      * 내 루트 삭제
      * [DELETE] /routes/{routeId}
      */

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -9,12 +9,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("routeLists")
 @RequiredArgsConstructor
 public class RouteListController {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.route.entity;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
+import com.umc.gusto.global.common.PublishStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -33,7 +34,15 @@ public class Route extends BaseEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String routeName;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "publishRoute", nullable = false, length = 10)
+    private PublishStatus publishRoute = PublishStatus.PUBLIC;
+
 
     public void updateStatus(BaseEntity.Status status) {this.status = status;}
     public void updateRouteName(String routeName){this.routeName = routeName;}
+    public void updatePublishRoute(PublishStatus status) {
+        this.publishRoute = status;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
@@ -11,7 +11,7 @@ public class RouteRequest {
     @NotBlank(message = "루트 명은 필수 입력값입니다.")
     private String routeName;
     private Long groupId;
-    private boolean publishRoute;
+    private boolean publishRoute; // public =>true , private => false
     private List<RouteListRequest> routeList;
 
     //isPublishRoute 대신 직접 지정

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.route.model.request;
 
+import com.umc.gusto.global.common.PublishStatus;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
@@ -10,5 +11,11 @@ public class RouteRequest {
     @NotBlank(message = "루트 명은 필수 입력값입니다.")
     private String routeName;
     private Long groupId;
+    private boolean publishRoute;
     private List<RouteListRequest> routeList;
+
+    //isPublishRoute 대신 직접 지정
+    public PublishStatus getPublishRoute() {
+        return this.publishRoute ? PublishStatus.PUBLIC: PublishStatus.PRIVATE;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteResponse.java
@@ -15,5 +15,8 @@ public class RouteResponse {
     private int numStore;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private boolean publishRoute;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long groupId;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -28,28 +28,28 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
 
     // 유저=본인
     // 가장 첫 페이징 유저의 루트 목록 조회, 그룹X
-    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByUserFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-    // 유저의 루트 목록 조회 , 그룹X, ACTIVE
-    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByUserFirstId(@Param("user") User user , Pageable pageable);
+    // 유저의 루트 목록 조회 , 그룹X
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , Pageable pageable);
 
     // 유저= 타인
-    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = :status AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByOtherFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-    @Query("select r from Route r where r.user = :user AND r.status = :status  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status,Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = 'ACTIVE' AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherFirstId(@Param("user") User user , Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE'  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId ,Pageable pageable);
 
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회
-    @Query("select r from Route r where r.group =:group AND r.status =:status AND r.routeId <:routeId ORDER BY r.createdAt DESC ")
-    Page<Route> findRoutesByGroup(@Param("group") Group group, @Param("routeId") Long routeId ,@Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.group =:group AND r.status ='ACTIVE' AND r.routeId <:routeId ORDER BY r.createdAt DESC ")
+    Page<Route> findRoutesByGroup(@Param("group") Group group, @Param("routeId") Long routeId , Pageable pageable);
 
     // 그룹의 루트 첫번째 호출
-    @Query("select r from Route r where r.group =:group AND r.status =:status ORDER BY r.createdAt DESC ")
-    Page<Route> findFirstRoutesByGroup(@Param("group") Group group,@Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.group =:group AND r.status = 'ACTIVE' ORDER BY r.createdAt DESC ")
+    Page<Route> findFirstRoutesByGroup(@Param("group") Group group, Pageable pageable);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route,Long> {
 
-    // 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
+    // 개인 루트내에서 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
     Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
+
+    // 그룹 내에서 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.group = :group")
     Boolean existsByGroupRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("group") Group group);
 
@@ -24,17 +26,20 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);
 
-    // 루트 단일 조회 그룹X, ACTIVE
-    @Query("SELECT r FROM Route r WHERE r.routeId = :routeId AND r.status = :status AND r.group.groupId IS NULL")
-    Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
-
-    // 가장 첫 페이징
+    // 유저=본인
+    // 가장 첫 페이징 유저의 루트 목록 조회, 그룹X
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
     Page<Route> findRouteByUserFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-
     // 유저의 루트 목록 조회 , 그룹X, ACTIVE
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByAfterIRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+
+    // 유저= 타인
+    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = :status AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = :status  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status,Pageable pageable);
+
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -17,6 +17,9 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
     Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.group = :group")
+    Boolean existsByGroupRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("group") Group group);
+
 
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -8,6 +8,7 @@ import com.umc.gusto.domain.user.entity.User;
 public interface RouteService {
     // 루트 생성
     void createRoute(RouteRequest request,User user);
+    void createRouteGroup(Long groupId,RouteRequest request,User user);
 
     // 루트 삭제
     void deleteRoute(Long routeId,User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -23,5 +23,5 @@ public interface RouteService {
     void modifyRouteList(Long routeId, ModifyRouteRequest request);
 
     // 타인의 루트 조회
-    RoutePagingResponse getRoute(String nickname, Long routeId);
+    RoutePagingResponse getOtherRoute(String nickname, Long routeId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -24,4 +24,7 @@ public interface RouteService {
 
     // 타인의 루트 조회
     RoutePagingResponse getOtherRoute(String nickname, Long routeId);
+
+    // 루트 공개/비공개 수정
+    void  modifyPublishingInfo(User user, Long routeId,boolean publishStatus);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -145,7 +145,7 @@ public class RouteServiceImpl implements RouteService{
                 .map(route -> RouteResponse.builder()
                         .routeId(route.getRouteId())
                         .routeName(route.getRouteName())
-                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC) // public => , private =>
+                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC)
                         .numStore(routeListRepository.countRouteListByRoute(route))
                         .build())
                 .collect(Collectors.toList());
@@ -256,6 +256,18 @@ public class RouteServiceImpl implements RouteService{
                 .hasNext(routes.hasNext())
                 .result(list)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void modifyPublishingInfo(User user, Long routeId, boolean publishStatus) {
+        Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
+        // 루트를 생성한 유저만 변경 가능
+        if(!route.getUser().getNickname().equals(user.getNickname())){
+            throw new GeneralException(Code.USER_NO_PERMISSION_FOR_ROUTE);
+        }
+        route.updatePublishRoute(publishStatus? PublishStatus.PUBLIC: PublishStatus.PRIVATE);
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -137,9 +137,9 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if(routeId == null) {
-            routes = routeRepository.findRouteByUserFirstId(user, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByUserFirstId(user, Pageable.ofSize(ROUTE_LIST_PAGE));
         }else{
-            routes = routeRepository.findRouteByAfterRouted(user,routeId, BaseEntity.Status.ACTIVE,Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByAfterRouted(user,routeId,Pageable.ofSize(ROUTE_LIST_PAGE));
         }
         List<RouteResponse> list = routes.getContent().stream()
                 .map(route -> RouteResponse.builder()
@@ -164,10 +164,10 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if(routeId == null) {
-            routes = routeRepository.findFirstRoutesByGroup(group, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findFirstRoutesByGroup(group, Pageable.ofSize(ROUTE_LIST_PAGE));
         }else{
             //특정 그룹 내 루트 조회
-            routes = routeRepository.findRoutesByGroup(group, routeId, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRoutesByGroup(group, routeId, Pageable.ofSize(ROUTE_LIST_PAGE));
         }
         return getRoutePagingResponse(routes);
 
@@ -239,9 +239,9 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if (routeId == null) {
-            routes = routeRepository.findRouteByOtherFirstId(user, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByOtherFirstId(user, Pageable.ofSize(ROUTE_LIST_PAGE));
         } else {
-            routes = routeRepository.findRouteByOtherAfterRouted(user, routeId, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByOtherAfterRouted(user, routeId, Pageable.ofSize(ROUTE_LIST_PAGE));
         }
 
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 루트 별 공개/비공개를 루트 생성과 루트 조회 시 설정 가능하도록 설계
- [ ] 버그 수정 :
- [x] 리펙토링 : 그룹 루트 추가와 개인 루트 로직 분리
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 로직 분리: 개인 루트에만 공개, 비공개 여부 존재, 루트명 설정 시 개인과 그룹에 따른 중복성 차이 존재 등으로 로직 분리
- 루트 공개/비공개 여부 기능 추가

### 작업 내역

- 루트 생성 시 공개/비공개 필드 추가
- 수정작업- 타인의 루트 조회 시 공개된 루트 한정 조건 추가
- 루트 목록 페이지에서 공개/비공개 변경 API 추가
- 그룹루트 로직 분리


### 작업 후 기대 동작(스크린샷)

- 개인 루트 추가
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/b9895270-da19-401e-936c-3eb3c541f60e)

- 타인의 루트 조회(마이페이지 공개)
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/a3c7c362-14c0-485d-ac30-78cb5161d789)

- 타인의 루트 조회(마이페이지 비공개)
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/a05a5b7a-998d-429f-9eb6-fadb00d5c72d)

- 루트 공개여부 변경
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/b9cbc509-c6a0-451c-b317-ac982bd56c89)

- 그룹 루트 추가
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/96f49095-401d-48df-a679-b2ce591d9ec0)

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #282 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
