### PR TITLE
Feat:  루트 내 이동 경로 순서 자동 부여

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -24,10 +24,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
   
     Boolean existsGroupMemberByGroupAndUser(Group group, User user);
 
-    @Query("SELECT COUNT(gm) " +
+    @Query("SELECT gm.group " +
             "FROM GroupMember gm LEFT JOIN gm.group g " +
             "WHERE g.groupId = :groupId AND gm.user = :user")
-    int existsByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
+    Group findByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
 
     Optional<GroupMember> findGroupMemberByGroupAndGroupMemberId(Group group, Long memberId);
     Optional<GroupMember> findGroupMemberByGroupAndUser(Group group, User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -3,11 +3,12 @@ package com.umc.gusto.domain.group.repository;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.GroupMember;
 import com.umc.gusto.domain.user.entity.User;
-import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -23,11 +24,18 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
   
     Boolean existsGroupMemberByGroupAndUser(Group group, User user);
 
+    @Query("SELECT COUNT(gm) " +
+            "FROM GroupMember gm LEFT JOIN gm.group g " +
+            "WHERE g.groupId = :groupId AND gm.user = :user")
+    int existsByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("user") User user);
+
     Optional<GroupMember> findGroupMemberByGroupAndGroupMemberId(Group group, Long memberId);
     Optional<GroupMember> findGroupMemberByGroupAndUser(Group group, User user);
   
     @Query("SELECT gm.group.groupId FROM GroupMember gm WHERE gm.user = :user")
     List<Long> findGroupIdsByUser(User user);
     int countGroupMembersByGroup(Group group);
+
+
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
@@ -1,7 +1,6 @@
 package com.umc.gusto.domain.group.repository;
 
 import com.umc.gusto.domain.group.entity.Group;
-import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +13,6 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findGroupByGroupIdAndStatus(Long groupId, BaseEntity.Status status);
-
     @Query("SELECT ic.group FROM InvitationCode ic WHERE ic.code = :code AND ic.group.status = :status")
     Optional<Group> findGroupByCodeAndStatus(@Param("code") String code, @Param("status") BaseEntity.Status status);
     @Query("SELECT g FROM Group g WHERE g.groupId IN :groupIds AND g.status = :status ORDER BY g.groupId DESC")

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -106,5 +106,18 @@ public class RouteController {
         return ResponseEntity.ok().body(route);
     }
 
+    /**
+     * 루트별 공개/비공개 설정
+     * [PATCH] /routes/{routeId}/publishing/{publishStatus}
+     */
+    @PatchMapping("/{routeId}/publishing/{publishStatus}")
+    public ResponseEntity modifyPublishingRoute(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long routeId,
+            @PathVariable boolean publishStatus)
+    {
+        routeService.modifyPublishingInfo(authUser.getUser(),routeId,publishStatus);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -102,7 +102,7 @@ public class RouteController {
     (@PathVariable String nickname,
      @RequestParam(required = false, name = "routeId") Long routeId
      ){
-        RoutePagingResponse route = routeService.getRoute(nickname,routeId);
+        RoutePagingResponse route = routeService.getOtherRoute(nickname,routeId);
         return ResponseEntity.ok().body(route);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -9,10 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequestMapping("routes")
 @RequiredArgsConstructor
 public class RouteController {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteController.java
@@ -32,6 +32,21 @@ public class RouteController {
     }
 
     /**
+     * 그룹 내 루트 추가
+     * [POST] /routes/{groupId}
+     */
+    // 루트 생성
+    @PostMapping("{groupId}")
+    public ResponseEntity<?> createRoute(
+            @PathVariable Long groupId,
+            @RequestBody RouteRequest request,
+            @AuthenticationPrincipal AuthUser authUSer)
+    {
+        routeService.createRouteGroup(groupId,request,authUSer.getUser());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
      * 내 루트 삭제
      * [DELETE] /routes/{routeId}
      */

--- a/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/controller/RouteListController.java
@@ -9,12 +9,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("routeLists")
 @RequiredArgsConstructor
 public class RouteListController {

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.route.entity;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
+import com.umc.gusto.global.common.PublishStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -33,7 +34,15 @@ public class Route extends BaseEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String routeName;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "publishRoute", nullable = false, length = 10)
+    private PublishStatus publishRoute = PublishStatus.PUBLIC;
+
 
     public void updateStatus(BaseEntity.Status status) {this.status = status;}
     public void updateRouteName(String routeName){this.routeName = routeName;}
+    public void updatePublishRoute(PublishStatus status) {
+        this.publishRoute = status;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
@@ -10,7 +10,6 @@ public class RouteListRequest {
     @NotNull(message = "루트 작성 시 식당 입력은 필수입니다.")
     private Long storeId;
 
-//    @NotNull(message = "루트 작성 시 식당 순서를 기입해주세요.")
     @DecimalMin(value = "1", message = "이동 순서가 1보다 작을 수 없습니다.")
     @DecimalMax(value = "6", message = "이동 순서가 6보다 클 수 없습니다.")
     private Integer ordinal;

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteListRequest.java
@@ -10,7 +10,7 @@ public class RouteListRequest {
     @NotNull(message = "루트 작성 시 식당 입력은 필수입니다.")
     private Long storeId;
 
-    @NotNull(message = "루트 작성 시 식당 순서를 기입해주세요.")
+//    @NotNull(message = "루트 작성 시 식당 순서를 기입해주세요.")
     @DecimalMin(value = "1", message = "이동 순서가 1보다 작을 수 없습니다.")
     @DecimalMax(value = "6", message = "이동 순서가 6보다 클 수 없습니다.")
     private Integer ordinal;

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
@@ -11,7 +11,7 @@ public class RouteRequest {
     @NotBlank(message = "루트 명은 필수 입력값입니다.")
     private String routeName;
     private Long groupId;
-    private boolean publishRoute;
+    private boolean publishRoute; // public =>true , private => false
     private List<RouteListRequest> routeList;
 
     //isPublishRoute 대신 직접 지정

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/request/RouteRequest.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.route.model.request;
 
+import com.umc.gusto.global.common.PublishStatus;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
@@ -10,5 +11,11 @@ public class RouteRequest {
     @NotBlank(message = "루트 명은 필수 입력값입니다.")
     private String routeName;
     private Long groupId;
+    private boolean publishRoute;
     private List<RouteListRequest> routeList;
+
+    //isPublishRoute 대신 직접 지정
+    public PublishStatus getPublishRoute() {
+        return this.publishRoute ? PublishStatus.PUBLIC: PublishStatus.PRIVATE;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteResponse.java
@@ -15,5 +15,8 @@ public class RouteResponse {
     private int numStore;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private boolean publishRoute;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long groupId;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.route.repository;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.entity.RouteList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -10,4 +11,7 @@ public interface RouteListRepository extends JpaRepository<RouteList,Long> {
     int countRouteListByRoute(Route route);
 
     List<RouteList> findByRouteOrderByOrdinalAsc(Route route); // 이동 순서 기준 정렬
+
+    @Query("select MAX(rl.ordinal) from RouteList  rl where rl.route = :route ")
+    Integer findLastRouteListOrdinal(Route route);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -28,28 +28,28 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
 
     // 유저=본인
     // 가장 첫 페이징 유저의 루트 목록 조회, 그룹X
-    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByUserFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-    // 유저의 루트 목록 조회 , 그룹X, ACTIVE
-    @Query("select r from Route r where r.user = :user AND r.status = :status AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByUserFirstId(@Param("user") User user , Pageable pageable);
+    // 유저의 루트 목록 조회 , 그룹X
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , Pageable pageable);
 
     // 유저= 타인
-    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = :status AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByOtherFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-    @Query("select r from Route r where r.user = :user AND r.status = :status  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status,Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = 'ACTIVE' AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherFirstId(@Param("user") User user , Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = 'ACTIVE'  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId ,Pageable pageable);
 
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회
-    @Query("select r from Route r where r.group =:group AND r.status =:status AND r.routeId <:routeId ORDER BY r.createdAt DESC ")
-    Page<Route> findRoutesByGroup(@Param("group") Group group, @Param("routeId") Long routeId ,@Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.group =:group AND r.status ='ACTIVE' AND r.routeId <:routeId ORDER BY r.createdAt DESC ")
+    Page<Route> findRoutesByGroup(@Param("group") Group group, @Param("routeId") Long routeId , Pageable pageable);
 
     // 그룹의 루트 첫번째 호출
-    @Query("select r from Route r where r.group =:group AND r.status =:status ORDER BY r.createdAt DESC ")
-    Page<Route> findFirstRoutesByGroup(@Param("group") Group group,@Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.group =:group AND r.status = 'ACTIVE' ORDER BY r.createdAt DESC ")
+    Page<Route> findFirstRoutesByGroup(@Param("group") Group group, Pageable pageable);
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route,Long> {
 
-    // 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
+    // 개인 루트내에서 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
     Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
+
+    // 그룹 내에서 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.group = :group")
     Boolean existsByGroupRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("group") Group group);
 
@@ -24,17 +26,20 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);
 
-    // 루트 단일 조회 그룹X, ACTIVE
-    @Query("SELECT r FROM Route r WHERE r.routeId = :routeId AND r.status = :status AND r.group.groupId IS NULL")
-    Optional<Route> findRouteByRouteIdAndStatusAndGroup(@Param("routeId") Long routeId, @Param("status") BaseEntity.Status status);
-
-    // 가장 첫 페이징
+    // 유저=본인
+    // 가장 첫 페이징 유저의 루트 목록 조회, 그룹X
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
     Page<Route> findRouteByUserFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
-
     // 유저의 루트 목록 조회 , 그룹X, ACTIVE
     @Query("select r from Route r where r.user = :user AND r.status = :status AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
-    Page<Route> findRouteByAfterIRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+    Page<Route> findRouteByAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status, Pageable pageable);
+
+    // 유저= 타인
+    @Query("select r from Route r where r.user = :user AND r.user.publishRoute ='PUBLIC' AND r.status = :status AND r.publishRoute ='PUBLIC' AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherFirstId(@Param("user") User user , @Param("status") BaseEntity.Status status, Pageable pageable);
+    @Query("select r from Route r where r.user = :user AND r.status = :status  AND r.publishRoute = 'PUBLIC' AND r.routeId <:routeId AND r.group.groupId IS NULL ORDER BY r.createdAt DESC")
+    Page<Route> findRouteByOtherAfterRouted(@Param("user") User user, @Param("routeId") Long routeId , @Param("status") BaseEntity.Status status,Pageable pageable);
+
 
     // 그룹의 루트 개수 조회
     int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -17,6 +17,9 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     // 동일한 이름의 루트가 있는지 확인 -> 존재하면 TRUE를 반환하고, 그렇지 않으면 FALSE
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.user = :user")
     Boolean existsByRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("user") User user);
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM Route r WHERE r.routeName = :routeName AND r.status = :status AND r.group = :group")
+    Boolean existsByGroupRouteName(@Param("routeName") String routeName, @Param("status") BaseEntity.Status status, @Param("group") Group group);
+
 
     // rootId PK값으로 루트 찾기
     Optional<Route> findRouteByRouteIdAndStatus(Long routeId,BaseEntity.Status status);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -74,11 +75,16 @@ public class RouteListServiceImpl implements RouteListService{
         Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
                 .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
         request.forEach(dto -> {
+            Integer ordinal = Optional.ofNullable(dto.getOrdinal())
+                    .orElseGet(() -> Optional.ofNullable(routeListRepository.findLastRouteListOrdinal(route))
+                            .map(lastOrdinal -> lastOrdinal + 1)
+                            .orElse(1));
+
             RouteList routeList = RouteList.builder()
                     .route(route)
                     .store(storeRepository.findById(dto.getStoreId())
                             .orElseThrow(() -> new GeneralException(Code.STORE_NOT_FOUND)))
-                    .ordinal(dto.getOrdinal() != null ? dto.getOrdinal() : routeListRepository.findLastRouteListOrdinal(route) + 1) //자동으로 가장 끝에 추가
+                    .ordinal(ordinal)
                     .build();
             routeListRepository.save(routeList);
         });

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -8,6 +8,7 @@ import com.umc.gusto.domain.user.entity.User;
 public interface RouteService {
     // 루트 생성
     void createRoute(RouteRequest request,User user);
+    void createRouteGroup(Long groupId,RouteRequest request,User user);
 
     // 루트 삭제
     void deleteRoute(Long routeId,User user);

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -23,5 +23,5 @@ public interface RouteService {
     void modifyRouteList(Long routeId, ModifyRouteRequest request);
 
     // 타인의 루트 조회
-    RoutePagingResponse getRoute(String nickname, Long routeId);
+    RoutePagingResponse getOtherRoute(String nickname, Long routeId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -24,4 +24,7 @@ public interface RouteService {
 
     // 타인의 루트 조회
     RoutePagingResponse getOtherRoute(String nickname, Long routeId);
+
+    // 루트 공개/비공개 수정
+    void  modifyPublishingInfo(User user, Long routeId,boolean publishStatus);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -145,7 +145,7 @@ public class RouteServiceImpl implements RouteService{
                 .map(route -> RouteResponse.builder()
                         .routeId(route.getRouteId())
                         .routeName(route.getRouteName())
-                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC) // public => , private =>
+                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC)
                         .numStore(routeListRepository.countRouteListByRoute(route))
                         .build())
                 .collect(Collectors.toList());
@@ -256,6 +256,18 @@ public class RouteServiceImpl implements RouteService{
                 .hasNext(routes.hasNext())
                 .result(list)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void modifyPublishingInfo(User user, Long routeId, boolean publishStatus) {
+        Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
+        // 루트를 생성한 유저만 변경 가능
+        if(!route.getUser().getNickname().equals(user.getNickname())){
+            throw new GeneralException(Code.USER_NO_PERMISSION_FOR_ROUTE);
+        }
+        route.updatePublishRoute(publishStatus? PublishStatus.PUBLIC: PublishStatus.PRIVATE);
     }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -89,12 +89,8 @@ public class RouteServiceImpl implements RouteService{
         if (routeRepository.existsByGroupRouteName(request.getRouteName(),BaseEntity.Status.ACTIVE,group)) {
             throw new GeneralException(Code.ROUTE_DUPLICATE_ROUTENAME);
         }
-        // 루트 리스트 갯수 6개 제한 확인
-        if(request.getRouteList().size()>=7){
-            throw new GeneralException(Code.ROUTELIST_TO_MANY_REQUEST);
-        }
 
-
+        // 그룹 루트는 루트명만 생성 가능
         // 루트 생성
         Route route = Route.builder()
                 .routeName(request.getRouteName())
@@ -105,11 +101,12 @@ public class RouteServiceImpl implements RouteService{
 
 
         if(request.getRouteList() != null){
+            // 루트 리스트 갯수 6개 제한 확인
+            if(request.getRouteList().size()>=7){
+                throw new GeneralException(Code.ROUTELIST_TO_MANY_REQUEST);
+            }
             // 루트리스트 생성 비지니스 로직 호출
             routeListService.createRouteList(savedRoute, request.getRouteList());
-        }else if(request.getGroupId() == null ){
-            // 내 루트 생성시에는 최소 1개 이상의 경로가 포함되어야 함
-            throw new GeneralException(Code.ROUTE_MYROUTE_BAD_REQUEST);
         }
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -137,9 +137,9 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if(routeId == null) {
-            routes = routeRepository.findRouteByUserFirstId(user, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByUserFirstId(user, Pageable.ofSize(ROUTE_LIST_PAGE));
         }else{
-            routes = routeRepository.findRouteByAfterRouted(user,routeId, BaseEntity.Status.ACTIVE,Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByAfterRouted(user,routeId,Pageable.ofSize(ROUTE_LIST_PAGE));
         }
         List<RouteResponse> list = routes.getContent().stream()
                 .map(route -> RouteResponse.builder()
@@ -164,10 +164,10 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if(routeId == null) {
-            routes = routeRepository.findFirstRoutesByGroup(group, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findFirstRoutesByGroup(group, Pageable.ofSize(ROUTE_LIST_PAGE));
         }else{
             //특정 그룹 내 루트 조회
-            routes = routeRepository.findRoutesByGroup(group, routeId, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRoutesByGroup(group, routeId, Pageable.ofSize(ROUTE_LIST_PAGE));
         }
         return getRoutePagingResponse(routes);
 
@@ -239,9 +239,9 @@ public class RouteServiceImpl implements RouteService{
 
         Page<Route> routes;
         if (routeId == null) {
-            routes = routeRepository.findRouteByOtherFirstId(user, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByOtherFirstId(user, Pageable.ofSize(ROUTE_LIST_PAGE));
         } else {
-            routes = routeRepository.findRouteByOtherAfterRouted(user, routeId, BaseEntity.Status.ACTIVE, Pageable.ofSize(ROUTE_LIST_PAGE));
+            routes = routeRepository.findRouteByOtherAfterRouted(user, routeId, Pageable.ofSize(ROUTE_LIST_PAGE));
         }
 
 

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -47,6 +47,7 @@ public enum Code {
     ROUTE_MYROUTE_BAD_REQUEST(HttpStatus.BAD_REQUEST,403305,"내 루트는 최소 1개 이상의 경로를 포함해야 합니다."),
     ROUTELIST_TO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS,403306,"루트 내 상점 항목은 최대 6개까지 가능합니다."),
     NO_PUBLIC_ROUTE(HttpStatus.FORBIDDEN,403307,"해당 루트는 비공개 상태입니다."),
+    ROUTE_ORDINAL_EMPTY_BAD_REQUEST(HttpStatus.BAD_REQUEST,403307,"루트 내 이동 경로는 비어둘 수 없습니다."),
 
     //Group 관련 에러 +4
     FIND_FAIL_GROUP(HttpStatus.NOT_FOUND, 404401, "존재하지 않는 그룹입니다."),

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -47,7 +47,7 @@ public enum Code {
     ROUTE_MYROUTE_BAD_REQUEST(HttpStatus.BAD_REQUEST,403305,"내 루트는 최소 1개 이상의 경로를 포함해야 합니다."),
     ROUTELIST_TO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS,403306,"루트 내 상점 항목은 최대 6개까지 가능합니다."),
     NO_PUBLIC_ROUTE(HttpStatus.FORBIDDEN,403307,"해당 루트는 비공개 상태입니다."),
-    ROUTE_ORDINAL_EMPTY_BAD_REQUEST(HttpStatus.BAD_REQUEST,403307,"루트 내 이동 경로는 비어둘 수 없습니다."),
+    ROUTE_ORDINAL_EMPTY_BAD_REQUEST(HttpStatus.BAD_REQUEST,403307,"루트 내 이동 경로는 필수 입력사항입니다."),
 
     //Group 관련 에러 +4
     FIND_FAIL_GROUP(HttpStatus.NOT_FOUND, 404401, "존재하지 않는 그룹입니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 루트 추가도 자연스럽게 맨 뒤로 들어가도록 수정
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 기존에는 루트 생성 시와 식당 추가 시 모두 경로 순서를 입력 받았으나, 추가 시에는 삭제시와 같이 내부적으로 순서 조정에 대한 프론트엔드 요청을 반영 

### 작업 내역

- ordinal 값을 자동으로 +1 증가

### 작업 후 기대 동작(스크린샷)

- 마지막 식당 입력 시에는 순서 미입력 시에도 내부적으로 반영하여 순서 조정
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/c5a6f9c6-0731-4cfd-a207-b1e1142c72d1)

- 루트 생성 시 순서 미입력 시에는 에러 발생
![image](https://github.com/gusto-umc/Gusto-Server/assets/84445176/c817f947-0370-4173-bc28-5cca9ff03fa7)



### PR 특이 사항

- #283 루트공개/비공개 관련 PR을 반영 후 병합해야 함!

### Issue Number 

close: #285 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?