### PR TITLE
hotfix: 소셜 에러 케이스 별 에러 메세지 분리

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
@@ -4,7 +4,7 @@ package com.umc.gusto.global.auth.service;
 import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SocialService {
     private final RestClient restClient = RestClient.create();
@@ -30,7 +31,7 @@ public class SocialService {
                     .header("Authorization", header)
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
-                        throw new GeneralException(Code.OAUTH_FIND_ERROR);
+                        throw new GeneralException(Code.OAUTH_NOT_FOUND_TOKEN);
                     }))
                     .onStatus(HttpStatusCode::is5xxServerError, ((request, response) -> {
                         throw new GeneralException(Code.OAUTH_FIND_ERROR);
@@ -40,12 +41,13 @@ public class SocialService {
             Map<String, String> response = new HashMap<>((LinkedHashMap) result.get("response"));
             id = response.get("id");
         } else if(provider.equals("GOOGLE")) {
+            log.info("Google start");
             Map result = restClient.get()
                     .uri("https://www.googleapis.com/oauth2/v2/userinfo")
                     .header("Authorization", header)
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
-                        throw new GeneralException(Code.OAUTH_FIND_ERROR);
+                        throw new GeneralException(Code.OAUTH_NOT_FOUND_TOKEN);
                     }))
                     .onStatus(HttpStatusCode::is5xxServerError, ((request, response) -> {
                         throw new GeneralException(Code.OAUTH_FIND_ERROR);
@@ -59,7 +61,7 @@ public class SocialService {
                     .header("Authorization", header)
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
-                        throw new GeneralException(Code.OAUTH_FIND_ERROR);
+                        throw new GeneralException(Code.OAUTH_NOT_FOUND_TOKEN);
                     }))
                     .onStatus(HttpStatusCode::is5xxServerError, ((request, response) -> {
                         throw new GeneralException(Code.OAUTH_FIND_ERROR);

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -77,6 +77,7 @@ public enum Code {
     // AUTH 관련 에러 +7
     UNMATCHED_AUTH_INFO(HttpStatus.FORBIDDEN, 403701, "AccessToken과 providerId가 일치하지 않습니다."),
     OAUTH_FIND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500701, "소셜 인증 서버에서 에러가 발생했습니다."),
+    OAUTH_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, 404702, "유효한 소셜 서버 Access Token이 아닙니다."),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 소셜 로그인 시 발생하는 에러 메세지를 분리했습니다.
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- #240 에서 처리했던 에러 처리가 미흡한 점이 있어 반환하는 에러 메세지를 수정하였습니다.

