### PR TITLE
[Feat]hard delete scheduler

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -179,7 +179,7 @@ public class GroupController {
     }
 
     /**
-     * 그룹 루트 삭제
+     * 그룹 루트 단일값 삭제
      * [DELETE] /groups/routes/{routeId}??groupId={groupId}
      */
     @DeleteMapping("/routes/{routeId}")

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
@@ -20,4 +20,7 @@ public interface GroupListRepository extends JpaRepository<GroupList,Long> {
     Page<GroupList> findGroupListByGroupOrderByCreatedAtDesc(@Param("group") Group group, @Param("groupListId") Long groupListId , Pageable pageable);
     int countGroupListsByGroup(Group group);
     Boolean existsGroupListByGroupAndStore(Group group, Store store);
+
+    @Query("DELETE FROM GroupList gl WHERE gl.group.groupId = :groupId")
+    void deleteByGroupId(@Param("groupId") Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupListRepository.java
@@ -6,6 +6,7 @@ import com.umc.gusto.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,6 +22,7 @@ public interface GroupListRepository extends JpaRepository<GroupList,Long> {
     int countGroupListsByGroup(Group group);
     Boolean existsGroupListByGroupAndStore(Group group, Store store);
 
+    @Modifying //DELETE 쿼리임을 명시
     @Query("DELETE FROM GroupList gl WHERE gl.group.groupId = :groupId")
     void deleteByGroupId(@Param("groupId") Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -6,6 +6,7 @@ import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,6 +37,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     List<Long> findGroupIdsByUser(User user);
     int countGroupMembersByGroup(Group group);
 
+    @Modifying //DELETE 쿼리임을 명시
     @Query("DELETE FROM GroupMember gm WHERE gm.group.groupId = :groupId")
     void deleteByGroupId(@Param("groupId") Long groupId);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupMemberRepository.java
@@ -36,6 +36,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     List<Long> findGroupIdsByUser(User user);
     int countGroupMembersByGroup(Group group);
 
+    @Query("DELETE FROM GroupMember gm WHERE gm.group.groupId = :groupId")
+    void deleteByGroupId(@Param("groupId") Long groupId);
 
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/GroupRepository.java
@@ -21,4 +21,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Query("SELECT g FROM Group g WHERE g.groupId IN :groupIds AND g.status = :status AND g.groupId < :lastGroupId ORDER BY g.groupId DESC")
     Page<Group> findGroupsByStatusAndGroupIdInLessThan(List<Long> groupIds, BaseEntity.Status status, Long lastGroupId, Pageable pageable);
 
+    @Query("SELECT g FROM Group g WHERE g.status = 'INACTIVE'")
+    List<Group> findAllInactiveGroups();
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
@@ -4,6 +4,7 @@ import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.InvitationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +13,7 @@ public interface InvitationCodeRepository extends JpaRepository<InvitationCode, 
     String findCodeByGroup(Group group);
   
     Optional<InvitationCode> findInvitationCodeByGroup(Group group);
+
+    @Query("DELETE FROM InvitationCode ic WHERE ic.group.groupId = :groupId")
+    void deleteByGroupId(@Param("groupId") Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/repository/InvitationCodeRepository.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.group.repository;
 import com.umc.gusto.domain.group.entity.Group;
 import com.umc.gusto.domain.group.entity.InvitationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,7 @@ public interface InvitationCodeRepository extends JpaRepository<InvitationCode, 
   
     Optional<InvitationCode> findInvitationCodeByGroup(Group group);
 
+    @Modifying //DELETE 쿼리임을 명시
     @Query("DELETE FROM InvitationCode ic WHERE ic.group.groupId = :groupId")
     void deleteByGroupId(@Param("groupId") Long groupId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -50,7 +50,7 @@ public interface GroupService {
     // 초대 코드로 그룹 정보 조회
     GetPreJoinGroupInfoResponse getPreJoinGroupInfo(JoinGroupRequest joinGroupRequest);
 
-    //그룹 루트 삭제
-    void deleteRoute(Long routeId, User user, Long groupId);
+    //
+    void hardDeleteAllSoftDeleted();
 
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -50,6 +50,9 @@ public interface GroupService {
     // 초대 코드로 그룹 정보 조회
     GetPreJoinGroupInfoResponse getPreJoinGroupInfo(JoinGroupRequest joinGroupRequest);
 
+    //그룹 루트 삭제
+    void deleteRoute(Long routeId, User user, Long groupId);
+
     //
     void hardDeleteAllSoftDeleted();
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -408,15 +408,15 @@ public class GroupServiceImpl implements GroupService{
         List<Group> deletedGroups = groupRepository.findAllInactiveGroups();
 
         for (Group group : deletedGroups) {
-            // Hard delete associated GroupList entities
+            // Hard delete  GroupList
             groupListRepository.deleteByGroupId(group.getGroupId());
-            // Hard delete associated GroupMember entities
+            // Hard delete GroupMember
             groupMemberRepository.deleteByGroupId(group.getGroupId());
-            // Hard delete associated InvitationCode entity
+            // Hard delete InvitationCode
             invitationCodeRepository.deleteByGroupId(group.getGroupId());
         }
 
-        // Hard delete Group entities
+        // Hard delete Group
         groupRepository.deleteAll(deletedGroups);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupServiceImpl.java
@@ -308,6 +308,22 @@ public class GroupServiceImpl implements GroupService{
     }
 
     @Override
+    public void deleteRoute(Long routeId, User user, Long groupId) {
+        // 그룹 구성원인지 확인
+        Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(()->new GeneralException(Code.FIND_FAIL_GROUP));
+        if(!groupMemberRepository.existsGroupMemberByGroupAndUser(group,user)){
+            throw new GeneralException(Code.USER_NOT_IN_GROUP);
+        }
+
+        Route route = routeRepository.findRouteByRouteIdAndStatus(routeId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new GeneralException(Code.ROUTE_NOT_FOUND));
+        //루트 삭제 : soft delete
+        route.updateStatus(BaseEntity.Status.INACTIVE);
+
+    }
+
+    @Override
     public void createGroupList(Long groupId,GroupListRequest request,User user) {
         // 그룹 존재 여부 확인
         Group group = groupRepository.findGroupByGroupIdAndStatus(groupId, BaseEntity.Status.ACTIVE)

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/entity/MyCategory.java
@@ -45,7 +45,7 @@ public class MyCategory extends BaseEntity{
     @JoinColumn(name = "userId")
     private User user;
 
-    @OneToMany(mappedBy = "myCategory", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "myCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Pin> pinList = new ArrayList<>();
 
     public void updateMyCategoryName(String myCategoryName) {

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/MyCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.domain.myCategory.repository;
 
 import com.umc.gusto.domain.myCategory.entity.MyCategory;
+import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,4 +29,6 @@ public interface MyCategoryRepository extends JpaRepository<MyCategory, Long> {
     @Query("SELECT m FROM MyCategory m WHERE m.status = 'ACTIVE' AND m.myCategoryId = :myCategoryId AND m.user = :user")
     Optional<MyCategory> findByUserAndMyCategoryId(User user, Long myCategoryId);
     List<MyCategory> findByUser(User user);
+    @Query("SELECT m FROM MyCategory m  WHERE m.status = 'INACTIVE'")
+    List<MyCategory> findAllInActive();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -6,7 +6,9 @@ import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -132,4 +134,9 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
             "AND t.townName = :townName " +
             "ORDER BY p.pinId DESC")
     List<Pin> findPinsByUserAndTownNameAndPinIdDESC(User user, String townName);
+
+
+    @Modifying //DELETE 쿼리임을 명시
+    @Query("DELETE FROM Pin p WHERE p.myCategory.myCategoryId = :myCategoryId")
+    void deleteByMyCategoryId(@Param("myCategoryId") Long myCategoryId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryService.java
@@ -25,4 +25,6 @@ public interface MyCategoryService {
     void modifyMyCategory(User user,Long myCategoryId, UpdateMyCategoryRequest request);
 
     void deleteMyCategories(User user, List<Long> myCategoryIds);
+
+    void hardDeleteAllSoftDeleted();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -265,4 +265,17 @@ public class MyCategoryServiceImpl implements MyCategoryService {
         }
     }
 
+    @Transactional
+    public void hardDeleteAllSoftDeleted() {
+        List<MyCategory> deletedMyCategories = myCategoryRepository.findAllInActive();
+
+//        for (MyCategory category : deletedMyCategories) {
+//            // Hard delete pin
+//            pinRepository.deleteByMyCategoryId(category.getMyCategoryId());
+//        }
+
+        // Hard delete myCategory
+        myCategoryRepository.deleteAll(deletedMyCategories);
+    }
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/LikedRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/LikedRepository.java
@@ -4,10 +4,17 @@ import com.umc.gusto.domain.review.entity.Liked;
 import com.umc.gusto.domain.review.entity.Review;
 import com.umc.gusto.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface LikedRepository extends JpaRepository<Liked, Long> {
     Optional<Liked> findByUserAndReview(User user, Review review);
     boolean existsByUserAndReview(User user, Review review);
+
+    @Modifying //DELETE 쿼리임을 명시
+    @Query("DELETE FROM Liked l WHERE l.review.reviewId = :reviewId")
+    void deleteByReviewId(@Param("reviewId") Long reviewId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -4,12 +4,12 @@ import com.umc.gusto.domain.review.entity.Review;
 import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -50,4 +50,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId, PageRequest pageRequest);
     @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.skipCheck=false AND t.hashTag.hasTagId = :hashTagId")
     List<Review> searchByHashTagContains(Long hashTagId, PageRequest pageRequest);
+
+    @Query("SELECT r FROM Review r WHERE r.status = 'INACTIVE'")
+    List<Review> findAllInActive();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewService.java
@@ -16,4 +16,5 @@ public interface ReviewService {
     ReviewDetailResponse getReview(Long reviewId);
     void likeReview(User user, Long reviewId);
     void unlikeReview(User user, Long reviewId);
+    void hardDeleteAllSoftDeleted();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -216,4 +216,21 @@ public class ReviewServiceImpl implements ReviewService{
         if(imageUrls.size()>3) review.updateImg4(imageUrls.get(3));
     }
 
+    @Transactional
+    public void hardDeleteAllSoftDeleted() {
+        // 비활성 상태의 리뷰를 찾기
+        List<Review> deletedReviews = reviewRepository.findAllInActive();
+
+        for (Review review : deletedReviews) {
+            // Review와 관련된 Tagging 삭제
+            // taggingRepository.deleteByReviewId(review.getReviewId());
+
+            // Review와 관련된 Liked 삭제
+            likedRepository.deleteByReviewId(review.getReviewId());
+        }
+
+        // 비활성 상태의 리뷰 삭제
+        reviewRepository.deleteAll(deletedReviews);
+    }
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/Route.java
@@ -9,6 +9,9 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -38,6 +41,9 @@ public class Route extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "publishRoute", nullable = false, length = 10)
     private PublishStatus publishRoute = PublishStatus.PUBLIC;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<RouteList> routeLists = new ArrayList<>();
 
 
     public void updateStatus(BaseEntity.Status status) {this.status = status;}

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
@@ -1,9 +1,11 @@
 package com.umc.gusto.domain.route.entity;
 
 import com.umc.gusto.domain.store.entity.Store;
-import com.umc.gusto.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -21,7 +23,7 @@ public class RouteList {
     @Column(nullable = false, updatable = false)
     private Long routeListId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "routeId", nullable = false)
     private Route route;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/entity/RouteList.java
@@ -23,7 +23,7 @@ public class RouteList {
     @Column(nullable = false, updatable = false)
     private Long routeListId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routeId", nullable = false)
     private Route route;
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
@@ -3,6 +3,7 @@ package com.umc.gusto.domain.route.repository;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.entity.RouteList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +17,7 @@ public interface RouteListRepository extends JpaRepository<RouteList,Long> {
     @Query("select MAX(rl.ordinal) from RouteList  rl where rl.route = :route ")
     Integer findLastRouteListOrdinal(Route route);
 
+    @Modifying //DELETE 쿼리임을 명시
     @Query("DELETE FROM RouteList rl WHERE rl.route.routeId = :routeId")
     void deleteByRouteId(@Param("routeId") Long routeId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteListRepository.java
@@ -4,6 +4,7 @@ import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.entity.RouteList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +15,7 @@ public interface RouteListRepository extends JpaRepository<RouteList,Long> {
 
     @Query("select MAX(rl.ordinal) from RouteList  rl where rl.route = :route ")
     Integer findLastRouteListOrdinal(Route route);
+
+    @Query("DELETE FROM RouteList rl WHERE rl.route.routeId = :routeId")
+    void deleteByRouteId(@Param("routeId") Long routeId);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -44,7 +44,7 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
 
 
     // 그룹의 루트 개수 조회
-    int countRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
+    List<Route> findRoutesByGroupAndStatus(Group group, BaseEntity.Status status);
 
     // 그룹의 루트 목록 조회
     @Query("select r from Route r where r.group =:group AND r.status ='ACTIVE' AND r.routeId <:routeId ORDER BY r.createdAt DESC ")
@@ -55,5 +55,7 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     Page<Route> findFirstRoutesByGroup(@Param("group") Group group, Pageable pageable);
 
     // 삭제요소 파악
-    List<Route> findRouteByStatusAndUpdatedAtBefore(BaseEntity.Status status, LocalDateTime dateTime);
+    @Query("SELECT r FROM Route r WHERE r.status = 'INACTIVE'")
+    List<Route> findAllInActive();
+
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +46,6 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     @Query("select r from Route r where r.group =:group AND r.status =:status ORDER BY r.createdAt DESC ")
     Page<Route> findFirstRoutesByGroup(@Param("group") Group group,@Param("status") BaseEntity.Status status, Pageable pageable);
 
-
     // 삭제요소 파악
-    List<Route> findRouteByStatus(BaseEntity.Status status);
+    List<Route> findRouteByStatusAndUpdatedAtBefore(BaseEntity.Status status, LocalDateTime dateTime);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/repository/RouteRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route,Long> {
@@ -44,4 +45,7 @@ public interface RouteRepository extends JpaRepository<Route,Long> {
     @Query("select r from Route r where r.group =:group AND r.status =:status ORDER BY r.createdAt DESC ")
     Page<Route> findFirstRoutesByGroup(@Param("group") Group group,@Param("status") BaseEntity.Status status, Pageable pageable);
 
+
+    // 삭제요소 파악
+    List<Route> findRouteByStatus(BaseEntity.Status status);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteService.java
@@ -27,4 +27,7 @@ public interface RouteService {
 
     // 루트 공개/비공개 수정
     void  modifyPublishingInfo(User user, Long routeId,boolean publishStatus);
+
+    //
+    void hardDeleteAllSoftDeleted();
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -15,6 +15,7 @@ import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.repository.UserRepository;
+import com.umc.gusto.global.DeleteSchedulingConfig;
 import com.umc.gusto.global.common.BaseEntity;
 import com.umc.gusto.global.common.PublishStatus;
 import com.umc.gusto.global.exception.Code;
@@ -40,6 +41,8 @@ public class RouteServiceImpl implements RouteService{
     private final RouteListService routeListService;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
+
+    private final DeleteSchedulingConfig schedulingConfig;
 
     private static final int ROUTE_LIST_PAGE = 6;
 
@@ -87,6 +90,8 @@ public class RouteServiceImpl implements RouteService{
 
         //루트 삭제 : soft delete // TODO:DB 최종 삭제 주기 체크
         route.updateStatus(BaseEntity.Status.INACTIVE);
+        //route.updateStatus(schedulingConfig.fixedRateScheduler());
+
 
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -274,12 +274,12 @@ public class RouteServiceImpl implements RouteService{
     public void hardDeleteAllSoftDeleted() {
         List<Route> deletedRoutes = routeRepository.findAllInActive();
 
-        for (Route route : deletedRoutes) {
-            // Hard delete associated RouteList entities
-            routeListRepository.deleteByRouteId(route.getRouteId());
-        }
+//        for (Route route : deletedRoutes) {
+//            // Hard delete RouteList
+//            routeListRepository.deleteByRouteId(route.getRouteId());
+//        }
 
-        // Hard delete Route entities
+        // Hard delete Route
         routeRepository.deleteAll(deletedRoutes);
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -269,4 +269,18 @@ public class RouteServiceImpl implements RouteService{
         route.updatePublishRoute(publishStatus? PublishStatus.PUBLIC: PublishStatus.PRIVATE);
     }
 
+
+    @Transactional
+    public void hardDeleteAllSoftDeleted() {
+        List<Route> deletedRoutes = routeRepository.findAllInActive().stream()
+                .collect(Collectors.toList());
+
+        for (Route route : deletedRoutes) {
+            // Hard delete associated RouteList entities
+            routeListRepository.deleteByRouteId(route.getRouteId());
+        }
+
+        // Hard delete Route entities
+        routeRepository.deleteAll(deletedRoutes);
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -272,8 +272,7 @@ public class RouteServiceImpl implements RouteService{
 
     @Transactional
     public void hardDeleteAllSoftDeleted() {
-        List<Route> deletedRoutes = routeRepository.findAllInActive().stream()
-                .collect(Collectors.toList());
+        List<Route> deletedRoutes = routeRepository.findAllInActive();
 
         for (Route route : deletedRoutes) {
             // Hard delete associated RouteList entities

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -15,7 +15,6 @@ import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.store.repository.StoreRepository;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.domain.user.repository.UserRepository;
-import com.umc.gusto.global.DeleteSchedulingConfig;
 import com.umc.gusto.global.common.BaseEntity;
 import com.umc.gusto.global.common.PublishStatus;
 import com.umc.gusto.global.exception.Code;
@@ -41,8 +40,6 @@ public class RouteServiceImpl implements RouteService{
     private final RouteListService routeListService;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
-
-    private final DeleteSchedulingConfig schedulingConfig;
 
     private static final int ROUTE_LIST_PAGE = 6;
 
@@ -90,7 +87,7 @@ public class RouteServiceImpl implements RouteService{
 
         //루트 삭제 : soft delete // TODO:DB 최종 삭제 주기 체크
         route.updateStatus(BaseEntity.Status.INACTIVE);
-        //route.updateStatus(schedulingConfig.fixedRateScheduler());
+
 
 
     }

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -2,11 +2,8 @@ package com.umc.gusto.global;
 
 import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.myCategory.service.MyCategoryService;
-import com.umc.gusto.domain.route.entity.Route;
-import com.umc.gusto.domain.route.repository.RouteListRepository;
-import com.umc.gusto.domain.route.repository.RouteRepository;
+import com.umc.gusto.domain.review.service.ReviewService;
 import com.umc.gusto.domain.route.service.RouteService;
-import com.umc.gusto.global.common.BaseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;
@@ -14,10 +11,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 
 @EnableScheduling
 @Configuration
@@ -28,16 +21,17 @@ public class DeleteSchedulingConfig {
     private final RouteService routeService;
     private final GroupService groupService;
     private final MyCategoryService myCategoryService;
+    private final ReviewService reviewService;
 
     // 일정 시간마다 실행
     @Transactional
     @Async
-    @Scheduled(fixedRate = 10000)
-    //@Scheduled(cron = "0 0 0 1 * ?") // 한 달 주기
+    @Scheduled(cron = "0 0 0 1 * ?") // 한 달 주기
     public void autoDelete() {
         routeService.hardDeleteAllSoftDeleted();
         groupService.hardDeleteAllSoftDeleted();
         myCategoryService.hardDeleteAllSoftDeleted();
+        reviewService.hardDeleteAllSoftDeleted();
 
     }
 

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -1,7 +1,6 @@
 package com.umc.gusto.global;
 
 import com.umc.gusto.domain.route.entity.Route;
-import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
 import com.umc.gusto.global.common.BaseEntity;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +11,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @EnableScheduling
@@ -21,30 +22,24 @@ import java.util.List;
 public class DeleteSchedulingConfig {
 // 삭제 시 상호 참조 주의!
     private final RouteRepository routeRepository;
-    private final RouteListRepository routeListRepository;
+//    private final RouteListRepository routeListRepository;
 
     // 일정 시간마다 실행
     @Transactional
     @Async
-    @Scheduled(cron = "0/60 * * * * ?")
+    @Scheduled(cron = "0 0 0 1 * ?")
     public void autoDelete() {
+        // 기간이 지난 데이터 : 30일 => 수정 시점을 기준 + 현재 상태
+        LocalDateTime threshold = LocalDateTime.now().minus(30, ChronoUnit.DAYS); // 현재 시간 기준 30일 이전
+
         // 각 리포지토리 DB별  삭제 대기를 찾아서 각자
-        List<Route> routes = routeRepository.findRouteByStatus(BaseEntity.Status.INACTIVE);
-        for (Route route : routes) {
-            // 각 Route에 관련된 RouteList 항목 삭제
-            routeListRepository.deleteAll(routeListRepository.findByRouteOrderByOrdinalAsc(route));
-        }
+        List<Route> routes = routeRepository.findRouteByStatusAndUpdatedAtBefore(BaseEntity.Status.INACTIVE,threshold);
+//        for (Route route : routes) {
+//            // 각 Route에 관련된 RouteList 항목 삭제
+//            routeListRepository.deleteAll(routeListRepository.findByRouteOrderByOrdinalAsc(route));
+//        }
         // 모든 Route 삭제
         routeRepository.deleteAll(routes);
         }
-
-
-    // 이전 작업이 완료된 후 7일마다 실행 (밀리초 단위)
-//    @Scheduled(fixedDelay = 1000)
-//    public BaseEntity.Status  fixedRateScheduler() {
-//        // 상태를 INACTIVE로 업데이트
-//        return BaseEntity.Status.INACTIVE;
-//
-//    }
 
 }

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.global;
 
 import com.umc.gusto.domain.group.service.GroupService;
+import com.umc.gusto.domain.myCategory.service.MyCategoryService;
 import com.umc.gusto.domain.route.entity.Route;
 import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
@@ -26,6 +27,7 @@ public class DeleteSchedulingConfig {
 // 삭제 시 상호 참조 주의!
     private final RouteService routeService;
     private final GroupService groupService;
+    private final MyCategoryService myCategoryService;
 
     // 일정 시간마다 실행
     @Transactional
@@ -35,6 +37,7 @@ public class DeleteSchedulingConfig {
     public void autoDelete() {
         routeService.hardDeleteAllSoftDeleted();
         groupService.hardDeleteAllSoftDeleted();
+        myCategoryService.hardDeleteAllSoftDeleted();
 
     }
 

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -24,16 +24,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeleteSchedulingConfig {
 // 삭제 시 상호 참조 주의!
-    private RouteService routeService;
-    private GroupService groupService;
-
+    private final RouteService routeService;
+    private final GroupService groupService;
 
     // 일정 시간마다 실행
     @Transactional
     @Async
-    @Scheduled(cron = "0 0 0 1 * ?") // 30일
+    @Scheduled(fixedRate = 10000)
+    //@Scheduled(cron = "0 0 0 1 * ?") // 한 달 주기
     public void autoDelete() {
-        // 각 수정 시점병 기간 필요성?
         routeService.hardDeleteAllSoftDeleted();
         groupService.hardDeleteAllSoftDeleted();
 

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -1,0 +1,50 @@
+package com.umc.gusto.global;
+
+import com.umc.gusto.domain.route.entity.Route;
+import com.umc.gusto.domain.route.repository.RouteListRepository;
+import com.umc.gusto.domain.route.repository.RouteRepository;
+import com.umc.gusto.global.common.BaseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@EnableScheduling
+@Configuration
+@Component
+@RequiredArgsConstructor
+public class DeleteSchedulingConfig {
+// 삭제 시 상호 참조 주의!
+    private final RouteRepository routeRepository;
+    private final RouteListRepository routeListRepository;
+
+    // 일정 시간마다 실행
+    @Transactional
+    @Async
+    @Scheduled(cron = "0/60 * * * * ?")
+    public void autoDelete() {
+        // 각 리포지토리 DB별  삭제 대기를 찾아서 각자
+        List<Route> routes = routeRepository.findRouteByStatus(BaseEntity.Status.INACTIVE);
+        for (Route route : routes) {
+            // 각 Route에 관련된 RouteList 항목 삭제
+            routeListRepository.deleteAll(routeListRepository.findByRouteOrderByOrdinalAsc(route));
+        }
+        // 모든 Route 삭제
+        routeRepository.deleteAll(routes);
+        }
+
+
+    // 이전 작업이 완료된 후 7일마다 실행 (밀리초 단위)
+//    @Scheduled(fixedDelay = 1000)
+//    public BaseEntity.Status  fixedRateScheduler() {
+//        // 상태를 INACTIVE로 업데이트
+//        return BaseEntity.Status.INACTIVE;
+//
+//    }
+
+}

--- a/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
+++ b/gusto/src/main/java/com/umc/gusto/global/DeleteSchedulingConfig.java
@@ -1,7 +1,10 @@
 package com.umc.gusto.global;
 
+import com.umc.gusto.domain.group.service.GroupService;
 import com.umc.gusto.domain.route.entity.Route;
+import com.umc.gusto.domain.route.repository.RouteListRepository;
 import com.umc.gusto.domain.route.repository.RouteRepository;
+import com.umc.gusto.domain.route.service.RouteService;
 import com.umc.gusto.global.common.BaseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -21,25 +24,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeleteSchedulingConfig {
 // 삭제 시 상호 참조 주의!
-    private final RouteRepository routeRepository;
-//    private final RouteListRepository routeListRepository;
+    private RouteService routeService;
+    private GroupService groupService;
+
 
     // 일정 시간마다 실행
     @Transactional
     @Async
-    @Scheduled(cron = "0 0 0 1 * ?")
+    @Scheduled(cron = "0 0 0 1 * ?") // 30일
     public void autoDelete() {
-        // 기간이 지난 데이터 : 30일 => 수정 시점을 기준 + 현재 상태
-        LocalDateTime threshold = LocalDateTime.now().minus(30, ChronoUnit.DAYS); // 현재 시간 기준 30일 이전
+        // 각 수정 시점병 기간 필요성?
+        routeService.hardDeleteAllSoftDeleted();
+        groupService.hardDeleteAllSoftDeleted();
 
-        // 각 리포지토리 DB별  삭제 대기를 찾아서 각자
-        List<Route> routes = routeRepository.findRouteByStatusAndUpdatedAtBefore(BaseEntity.Status.INACTIVE,threshold);
-//        for (Route route : routes) {
-//            // 각 Route에 관련된 RouteList 항목 삭제
-//            routeListRepository.deleteAll(routeListRepository.findByRouteOrderByOrdinalAsc(route));
-//        }
-        // 모든 Route 삭제
-        routeRepository.deleteAll(routes);
-        }
+    }
 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 스프링부트 스케줄링을 통한 hard delete 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 그룹 삭제 로직에서 그룹 INACTIVE 시 그룹 내 루트 INACTIVE 변경 로직 추가
기존에는 그룹 삭제 시 그룹만 INACTIVE로 변경하여 차후 스케줄링을 통한 herd delete 시 DB 연관관계로 참조 무결성에 의해 루트가 있어 삭제되지 않는 오류 발생합니다. 그룹 INACTIVE 시 그룹 내 루트 목록들도 INACTIVE 작업 추가했습니다. 

### 작업 내역
- Group Entity  hard delete 시에 GroupList, GroupMemer, InvitationCode 도 DB에서 삭제
- Route Entity   hard delete 시에 RouteList도 DB에서 삭제
- MyCategory Entity   hard delete 시에 pin도 DB에서 삭제
- Review Entity   hard delete 시에 Liked, Tagging도 DB에서 삭제


### PR 특이 사항

- 부모-자식 연관관계에 따른 스케줄링 순서에 영향을 받음(즉, 자식 삭제 스케줄링 작업 이후 부모 삭제 스케줄링 작업이 진행되야 함)

### Issue Number 

close: #274 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
현재는 기존 엔티티 코드기반으로 진행했는데요. 방법을 크게 2가지로 나눌 수 있더라구요, 
하나의 방식으로 통일 시키는 것이 좋을 것 같아서 조언을 얻고자 합니다!

방법1)
현재 @ManyToOne  , @OneToMany로 양방향 관계를 형성으로 cascade와 orphanRemoval 설정을 추가함,  쿼리문을 직접 작성하지 않음
-> 현재 Route, myCategory, review-tagging 적용됨

방법2) 
각 부모 엔티티 중 INACTIVE인 것을 찾아서 반복문으로 각 pk 식별자를 외래키로 가진 자식 엔티티를 삭제하고, 후에 부모 엔티티를 삭제하는 방식
이 방식은 직접 삭제 쿼리문을 repositoty 단에 작성해야 함
->현재 Group, Review-liked 적용됨