### PR TITLE
[refactor] 내 루트 조회할 때나 루트 상세 조회 시 공개/비공개 여부 포함하도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteRouteListResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/model/response/RouteRouteListResponse.java
@@ -1,5 +1,6 @@
 package com.umc.gusto.domain.route.model.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,5 +15,7 @@ import java.util.List;
 public class RouteRouteListResponse {
     private Long routeId;
     private String routeName;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private boolean publishRoute;
     private List<RouteListResponse> routes;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteListServiceImpl.java
@@ -163,6 +163,7 @@ public class RouteListServiceImpl implements RouteListService{
         return RouteRouteListResponse.builder()
                 .routeId(route.getRouteId())
                 .routeName(route.getRouteName())
+                .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC ? true : false)
                 .routes(routeLists)
                 .build();
 

--- a/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/route/service/RouteServiceImpl.java
@@ -142,7 +142,7 @@ public class RouteServiceImpl implements RouteService{
                 .map(route -> RouteResponse.builder()
                         .routeId(route.getRouteId())
                         .routeName(route.getRouteName())
-                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC)
+                        .publishRoute(route.getPublishRoute() == PublishStatus.PUBLIC ? true : false)
                         .numStore(routeListRepository.countRouteListByRoute(route))
                         .build())
                 .collect(Collectors.toList());


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 : 
- [ ] 버그 수정 :
- [x] 리펙토링 : 이전 루트 공개/비공개 작업 지 조회 API에 해당하는 변수를 추가하지 않고 작업하여 수정함
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- Response에 공개/비공개 여부에 해당하는 변수 추가

### 작업 후 기대 동작(스크린샷)

- 내 루트 조회
![image](https://github.com/user-attachments/assets/796e59e4-a76a-488f-afcb-13f40b8c73e7)
- 루트 상세 조회
![image](https://github.com/user-attachments/assets/f986dc3a-f302-4869-8a27-fb5d8fe2c77b)

### Issue Number 

close: #283 
