### PR TITLE
feat: 프로필 업데이트 시 기본 이미지 사용 케이스 추가

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/model/request/UpdateProfileRequest.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/model/request/UpdateProfileRequest.java
@@ -11,4 +11,5 @@ public class UpdateProfileRequest {
     String nickname;
     String age;
     String gender;
+    Boolean useDefaultImg;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -248,6 +248,10 @@ public class UserServiceImpl implements UserService{
             if(request.getNickname() != null) {
                 updateNickname(user, request.getNickname());
             }
+
+            if(Optional.ofNullable(request.getUseDefaultImg()).orElse(false)) {
+                user.updateProfile(DEFAULT_PROFILE_IMG);
+            }
         }
 
         userRepository.save(user);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 프로필 업데이트 시 기본 이미지 사용
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 프로필 업데이트 시, 서비스 기본 이미지를 선택할 수 있도록 수정했습니다.
