### PR TITLE
fix: 랜덤 피드 API 관련 repository에서 VO를 사용하지 않아 발생한 문제 해결

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,7 +9,6 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.2.1/9d6ac9a2fa98598d1a38e9f06d6f0aab250cae2f/spring-boot-configuration-processor-3.2.1.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
         </processorPath>
-        <module name="com.umc.gusto.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/.idea/modules/gusto.main.iml
+++ b/.idea/modules/gusto.main.iml
@@ -5,15 +5,4 @@
       <sourceFolder url="file://$MODULE_DIR$/../../gusto/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
     </content>
   </component>
-  <component name="FacetManager">
-    <facet type="jpa" name="JPA">
-      <configuration>
-        <setting name="validation-enabled" value="true" />
-        <datasource-mapping>
-          <factory-entry name="entityManagerFactory" />
-        </datasource-mapping>
-        <naming-strategy-map />
-      </configuration>
-    </facet>
-  </component>
 </module>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java" dialect="GenericSQL" />
+  </component>
+</project>

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/FeedVO.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/FeedVO.java
@@ -1,0 +1,6 @@
+package com.umc.gusto.domain.review.model;
+
+public interface FeedVO {
+    Long getReviewId();
+    String getImage();
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/review/model/response/RandomFeedResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/model/response/RandomFeedResponse.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.domain.review.model.response;
 
 import com.umc.gusto.domain.review.entity.Review;
+import com.umc.gusto.domain.review.model.FeedVO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +15,13 @@ public class RandomFeedResponse {
         return RandomFeedResponse.builder()
                 .reviewId(review.getReviewId())
                 .images(review.getImg1())
+                .build();
+    }
+
+    public static RandomFeedResponse of(FeedVO feedVO){
+        return RandomFeedResponse.builder()
+                .reviewId(feedVO.getReviewId())
+                .images(feedVO.getImage())
                 .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.domain.review.repository;
 
 import com.umc.gusto.domain.review.entity.Review;
+import com.umc.gusto.domain.review.model.FeedVO;
 import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
@@ -37,8 +38,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Page<Review>> findAllByUserAndStatus(User user, BaseEntity.Status status, PageRequest pageRequest);
     List<Review> findByUserAndStatusAndVisitedAtBetween(User user, BaseEntity.Status status, LocalDate startDate, LocalDate lastDate);
 
-    @Query(value = "SELECT * FROM review r join user u on r.user_id = u.user_id  WHERE r.user_id <> :user AND u.publish_review = 'PUBLIC' AND r.status = 'ACTIVE' AND r.publish_review = 'PUBLIC' AND r.skip_check=false ORDER BY RAND() limit 33", nativeQuery = true)
-    List<Review> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
+    @Query(value = "SELECT r.review_id as reviewId, r.img1 as image FROM review r join user u on r.user_id = u.user_id  WHERE r.user_id <> :user AND u.publish_review = 'PUBLIC' AND r.status = 'ACTIVE' AND r.publish_review = 'PUBLIC' AND r.skip_check=false ORDER BY RAND() limit 33", nativeQuery = true)
+    List<FeedVO> findRandomFeedByUser(@Param("user") UUID user); //WHERE r.user_id <> :userZ
 
     boolean existsByStoreAndUserNickname(Store store, String nickname);
 

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -1,6 +1,7 @@
 package com.umc.gusto.domain.review.service;
 
 import com.umc.gusto.domain.review.entity.Review;
+import com.umc.gusto.domain.review.model.FeedVO;
 import com.umc.gusto.domain.review.model.response.*;
 import com.umc.gusto.domain.review.repository.LikedRepository;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
@@ -27,7 +28,8 @@ public class FeedServiceImpl implements FeedService{
 
     @Override
     public List<RandomFeedResponse> getRandomFeed(User user) {
-        List<Review> feedList = reviewRepository.findRandomFeedByUser(user.getUserId());
+//        List<Review> feedList = reviewRepository.findRandomFeedByUser(user.getUserId());
+        List<FeedVO> feedList = reviewRepository.findRandomFeedByUser(user.getUserId());
         return feedList.stream().map(RandomFeedResponse::of).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 랜덤 피드 API 관련 repository에서 VO를 사용하지 않아 발생한 문제 해결
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 이유: 랜덤 피드 API에서 500에러가 터지고 있었음
- 원인: repository의 nativeQuery의 경우, entity로 변환이 바로 안된다. VO클래스를 사용해서 받아야 한다. 

### 작업 내역
원인을 바탕으로 VO클래스를 만들어서 JPA 메소드의 반환 값으로 사용하도록 수정

### Issue Number 
close: #

