### PR TITLE
refactor : 타인의 카테고리 속 가게 조회 시 User 정보 사용하던 에러처리 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -95,9 +95,6 @@ public class MyCategoryServiceImpl implements MyCategoryService {
 
         Page<Pin> pinList;
         if (nickname != null) {
-            if (nickname.equals(user.getNickname())) {
-                throw new GeneralException(Code.USER_NOT_FOUND_SELF);
-                }
             user = userRepository.findByNickname(nickname)
                     .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
             myCategory = myCategoryRepository.findByMyCategoryPublicIdAndUserNickname(nickname, myCategoryId);          // PUBLIC 값에 따라 보이는 CATEGORY 처리, PIN에서까지 하지않아도 됨

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -13,7 +13,6 @@ public enum Code {
 
     //User 관련 에러 +0
     USER_FOLLOW_SELF(HttpStatus.FORBIDDEN, 403001, "자신을 팔로우할 수 없습니다."),
-    USER_NOT_FOUND_SELF(HttpStatus.FORBIDDEN, 403002, "자신의 닉네임을 사용해 접근할 수 없습니다."),
     USER_PUBLISH_CATEGORY_PRIVATE(HttpStatus.FORBIDDEN, 403003, "마이페이지의 publishCategory가 PRIVATE 상태입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404001, "존재하지 않는 유저입니다."),
     USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, 404002, "팔로우한 유저가 아닙니다."),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 타인 카레고리 속 가게 조회 시 User 정보를 안받으면서 수정되지 않은 부분 추가 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 타인 카레고리 속 가게 조회 시 User 정보를 안받게 되면서 토큰을 통해 타인 카테고리 조회 시 자신의 닉네임으로 조회하고 있는 지 확인하는 부분이 있었으나 로직상 일어날 가능성이 적다 생각해 삭제하였습니다.

### 작업 내역

- 타인 카테고리 조회 시 자신의 닉네임으로 조회하고 있는 지 확인하는 부분 삭제

### Issue Number 

close: #300

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
* 오류 해결을 위해 코드를 일부 삭제했을 뿐 크게 변한 내용은 없습니다
