### PR TITLE
fix: social 연동 관련 버그 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -312,7 +312,7 @@ public class UserController {
 
     /**
      * 연결된 소셜 계정 목록
-     * [POST] /users/social-accounts
+     * [GET] /users/social-accounts
      * @param -
      * @return -
      */

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -286,7 +286,7 @@ public class UserController {
      * @param -
      * @return -
      */
-    @DeleteMapping("/auth/disconnect-social-account")
+    @DeleteMapping("/auth/social-account")
     public ResponseEntity disconnectSocialAccount(@AuthenticationPrincipal AuthUser authUser,
                                                   @RequestBody @Valid SignInRequest signInRequest) {
 
@@ -301,7 +301,7 @@ public class UserController {
      * @param -
      * @return -
      */
-    @PostMapping("/auth/connect-social-account")
+    @PostMapping("/auth/social-account")
     public ResponseEntity connectSocialAccount(@AuthenticationPrincipal AuthUser authUser,
                                                @RequestBody @Valid SignInRequest signInRequest) {
         userService.connectSocialAccount(authUser.getUser(), signInRequest);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/controller/UserController.java
@@ -286,7 +286,7 @@ public class UserController {
      * @param -
      * @return -
      */
-    @DeleteMapping("/auth/social-account")
+    @DeleteMapping("/auth/disconnect-social-account")
     public ResponseEntity disconnectSocialAccount(@AuthenticationPrincipal AuthUser authUser,
                                                   @RequestBody @Valid SignInRequest signInRequest) {
 
@@ -301,7 +301,7 @@ public class UserController {
      * @param -
      * @return -
      */
-    @PostMapping("/auth/social-account")
+    @PostMapping("/auth/connect-social-account")
     public ResponseEntity connectSocialAccount(@AuthenticationPrincipal AuthUser authUser,
                                                @RequestBody @Valid SignInRequest signInRequest) {
         userService.connectSocialAccount(authUser.getUser(), signInRequest);

--- a/gusto/src/main/java/com/umc/gusto/domain/user/repository/SocialRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/repository/SocialRepository.java
@@ -14,5 +14,7 @@ public interface SocialRepository extends JpaRepository<Social, Long> {
 
     Boolean existsByUserAndSocialType(User user, Social.SocialType socialType);
 
+    Boolean existsBySocialTypeAndProviderId(Social.SocialType socialType, String providerId);
+
     List<Social> findByUser(User user);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/user/service/UserServiceImpl.java
@@ -425,6 +425,11 @@ public class UserServiceImpl implements UserService{
             throw new GeneralException(Code.ALREADY_EXIST_SOCIAL_CONNECT);
         }
 
+        if(socialRepository.existsBySocialTypeAndProviderId(Social.SocialType.valueOf(signInRequest.getProvider()),
+                signInRequest.getProviderId())) {
+            throw new GeneralException(Code.ALREADY_EXIST_CONNECTED_ACCOUNT);
+        }
+
         Social social = Social.builder()
                 .user(user)
                 .socialType(Social.SocialType.valueOf(signInRequest.getProvider()))

--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
@@ -21,9 +21,9 @@ public class SocialService {
     private final RestClient restClient = RestClient.create();
     private static final String AUTH_TYPE = "Bearer ";
     @Value("${spring.security.oauth2.client.registration.naver.client-id}")
-    private static String NAVER_CLIENT_ID;
+    private String NAVER_CLIENT_ID;
     @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
-    private static String NAVER_CLIENT_SECRET;
+    private String NAVER_CLIENT_SECRET;
 
     public void checkUserInfo(String provider, String providerId, String accessToken) {
         // TODO: ACCESS TOKEN 복호화
@@ -91,8 +91,8 @@ public class SocialService {
             uri.append("client_id=").append(NAVER_CLIENT_ID).append("&")
                     .append("client_secret=").append(NAVER_CLIENT_SECRET).append("&")
                     .append("access_token=").append(accessToken);
-
-            Map result = restClient.get()
+            System.out.println(uri);
+            Map result = restClient.post()
                     .uri(uri.toString())
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -80,7 +80,8 @@ public enum Code {
     UNMATCHED_AUTH_INFO(HttpStatus.FORBIDDEN, 403701, "AccessToken과 providerId가 일치하지 않습니다."),
     NEED_LEAST_ONE_SOCIAL_ACCOUNT(HttpStatus.FORBIDDEN, 403702, "최소 1개의 소셜 계정이 연동되어야 합니다."),
     SOCIAL_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404701, "해당 소셜 계정이 연결되어 있지 않습니다."),
-    ALREADY_EXIST_SOCIAL_CONNECT(HttpStatus.CONFLICT, 409701, "해당 소셜 서비스에 연결된 계정이 이미 존재합니다."),
+    ALREADY_EXIST_SOCIAL_CONNECT(HttpStatus.CONFLICT, 409701, "해당 소셜 서비스에 이미 연결되었습니다."),
+    ALREADY_EXIST_CONNECTED_ACCOUNT(HttpStatus.CONFLICT, 409702, "해당 소셜 계정에 연결된 계정이 이미 존재합니다."),
     OAUTH_FIND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500701, "소셜 인증 서버에서 에러가 발생했습니다."),
     OAUTH_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, 404702, "유효한 소셜 서버 Access Token이 아닙니다."),
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 소셜 연동 관련 버그 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

1. 소셜 연동 계정 추가 시에 이미 연동이 존재하는 계정이 추가되는 문제
  - 소셜  연동 추가 시 추가하려는 계정과 연결된 계정이 존재하는지 확인하는 단계 추가 
2. 네이버 소셜 연동 해제 시도 시 gusto에서는 정보가 삭제되나, 네이버 연동이 해제되지 않았음
  - `@Value` 어노테이션을 사용하는 변수에 잘못된 `static` 구문 사용으로 제대로 값 바인딩이 되지 않아 네이버에 올바른 요청을 하지 못하고 있었음. 
