### PR TITLE
refactor: 검색 시 대소문자, 공백 무시 & 가게 검색 페이징 처리

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -47,12 +47,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         검색 관련
      */
     @Query("SELECT r FROM Review r WHERE r.status = 'ACTIVE' AND r.publishReview = 'PUBLIC' AND r.skipCheck = false " +
-            "AND r.reviewId < :cursorId AND r.store.storeName like concat('%', :keyword, '%') OR r.comment like concat('%', :keyword, '%')" +
+            "AND r.reviewId < :cursorId " +
+            "AND (REPLACE(r.store.storeName, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))" +
+            " OR REPLACE(r.comment, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')))" +
             "ORDER BY r.reviewId desc")
     Page<Review> searchByStoreContains(String keyword, Long cursorId, PageRequest pageRequest); //TODO: 후에 페이징 처리 하기
     @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.publishReview = 'PUBLIC' AND t.review.skipCheck=false " +
-            "AND t.review.reviewId < :cursorId AND t.review.store.storeName like concat('%', :keyword, '%') AND t.hashTag.hasTagId = :hashTagId" +
-            " ORDER BY t.review.reviewId desc")
+            "AND t.review.reviewId < :cursorId " +
+            "AND t.hashTag.hasTagId = :hashTagId " +
+            "AND (REPLACE(t.review.store.storeName, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))" +
+            " OR REPLACE(t.review.comment, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))) " +
+            "ORDER BY t.review.reviewId desc")
     Page<Review> searchByStoreAndHashTagContains(String keyword, Long hashTagId, Long cursorId, PageRequest pageRequest);
     @Query("SELECT t.review FROM Tagging t WHERE t.review.status = 'ACTIVE' AND t.review.publishReview = 'PUBLIC' AND t.review.skipCheck=false " +
             "AND t.review.reviewId < :cursorId AND t.hashTag.hasTagId = :hashTagId ORDER BY t.review.reviewId desc")

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/FeedServiceImpl.java
@@ -65,7 +65,7 @@ public class FeedServiceImpl implements FeedService{
 
         boolean checkNext = searchResult.hasNext();
         List<BasicViewResponse> basicViewResponse = searchResult.stream().map(BasicViewResponse::of).toList();
-        Long cursorId = basicViewResponse.isEmpty() ? null : basicViewResponse.get(basicViewResponse.size()-1).getReviewId();
+        Long cursorId = basicViewResponse.isEmpty() || !checkNext ? null : basicViewResponse.get(basicViewResponse.size()-1).getReviewId();
 
         return SearchFeedResponse.of(basicViewResponse, checkNext, cursorId);
     }

--- a/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/service/ReviewServiceImpl.java
@@ -20,7 +20,6 @@ import com.umc.gusto.global.exception.Code;
 import com.umc.gusto.global.exception.GeneralException;
 import com.umc.gusto.global.exception.customException.NoPermission;
 import com.umc.gusto.global.exception.customException.NotFoundException;
-import com.umc.gusto.global.exception.customException.PrivateItemException;
 import com.umc.gusto.global.util.S3Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/controller/StoreController.java
@@ -117,7 +117,7 @@ public class StoreController {
      * 맛집 검색 엔진
      */
     @GetMapping("/search")
-    public ResponseEntity<List<GetStoreInfoResponse>> searchStore(@RequestParam(name = "keyword") String keyword){
-        return ResponseEntity.status(HttpStatus.OK).body(storeService.searchStore(keyword));
+    public ResponseEntity<SearchStoreResponse> searchStore(@RequestParam(name = "keyword") String keyword, @RequestParam(name = "cursorId", required = false) Long cursorId){
+        return ResponseEntity.status(HttpStatus.OK).body(storeService.searchStore(keyword, cursorId));
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/SearchStoreResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/SearchStoreResponse.java
@@ -1,0 +1,22 @@
+package com.umc.gusto.domain.store.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class SearchStoreResponse {
+    List<GetStoreInfoResponse> stores;
+    boolean hasNext;
+    Long cursorId;
+
+    public static SearchStoreResponse of(List<GetStoreInfoResponse> stores, boolean hasNext, Long cursorId) {
+        return SearchStoreResponse.builder()
+                .stores(stores)
+                .hasNext(hasNext)
+                .cursorId(cursorId)
+                .build();
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
@@ -1,6 +1,8 @@
 package com.umc.gusto.domain.store.repository;
 
 import com.umc.gusto.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,4 +13,9 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     List<Store> findByTownNameAndStoreIds(String townName, List<Long> storeIds);
 
     List<Store> findTop5ByStoreNameContains(String keyword);
+
+    @Query("SELECT s FROM Store s WHERE s.storeStatus = 'ACTIVE' AND s.storeId < :cursorId " +
+            "AND (REPLACE(s.storeName, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
+            "OR REPLACE(s.categoryString, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')))")
+    Page<Store> searchByStoreNameContains(String keyword, Long cursorId, PageRequest pageRequest);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreService.java
@@ -16,5 +16,5 @@ public interface StoreService {
     List<GetPinStoreResponse> getPinStoresByCategoryAndLocation(User user, Long myCategoryId, String townName);
     Map<String, Object> getVisitedPinStores(User user, Long myCategoryId, String townName, Long lastStoreId, int size);
     Map<String, Object> getUnvisitedPinStores(User user, Long myCategoryId, String townName, Long lastStoreId, int size);
-    List<GetStoreInfoResponse> searchStore(String keyword);
+    SearchStoreResponse searchStore(String keyword, Long cursor);
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 리뷰 검색에는 페이징 처리가 되어 있으나 가게 검색에 누락되어있습니다.
- 검색 시 대소문자, 공백을 정확히 입력해야 검색되는 상황이었습니다.

### 작업 내역
- 가게 검색 페이징 처리
- 검색에 사용되는 컬럼에 utf8mb4_general_ci 속성을 추가
   해당 속성을 부여하면 데이터를 검색할 때 대소문자와 관계없이 일치 여부를 확인할 수 있습니다.
- 검색 쿼리에 공백을 제거하고 비교하도록 수정

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
