### PR TITLE
feat: 소셜 로그인 정보 암호화

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
@@ -3,6 +3,7 @@ package com.umc.gusto.global.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.gusto.domain.user.model.response.FirstLogInResponse;
 import com.umc.gusto.global.auth.model.Tokens;
+import com.umc.gusto.global.auth.service.AuthService;
 import com.umc.gusto.global.auth.service.JwtService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import java.io.IOException;
 public class AuthController {
     private final ObjectMapper objectMapper;
     private final JwtService jwtService;
+    private final AuthService authService;
 
     @GetMapping("/result/member")
     public void returnLoginResult(HttpServletResponse response,
@@ -58,5 +60,13 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .headers(headers)
                 .build();
+    }
+
+    @GetMapping("/decoding")
+    public ResponseEntity decoding(@RequestParam("value") String value) {
+        String result = authService.decode(value);
+
+        return ResponseEntity.ok()
+                .body(result);
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/CustomAuthenticationSuccessHandler.java
@@ -5,7 +5,7 @@ import com.umc.gusto.global.auth.model.CustomOAuth2User;
 import com.umc.gusto.global.auth.model.OAuthAttributes;
 import com.umc.gusto.global.auth.model.Tokens;
 import com.umc.gusto.global.auth.service.JwtService;
-import com.umc.gusto.global.auth.service.OAuthService;
+import com.umc.gusto.global.auth.service.AuthService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,7 +22,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private final JwtService jwtService;
-    private final OAuthService oAuthService;
+    private final AuthService authService;
     @Value("${default.login.redirect.url}")
     private String redirectUrl;
 

--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/AuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/AuthService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class OAuthService extends DefaultOAuth2UserService {
+public class AuthService extends DefaultOAuth2UserService {
     private final SocialRepository socialRepository;
     private final UserService userService;
     @Value("${default.img.url}")
@@ -78,5 +78,9 @@ public class OAuthService extends DefaultOAuth2UserService {
                 .build();
     }
 
+    public String decode(String cryptogram) {
+        String result = "";
 
+        return result;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/SocialService.java
@@ -18,6 +18,7 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 public class SocialService {
+    private final AuthService authService;
     private final RestClient restClient = RestClient.create();
     private static final String AUTH_TYPE = "Bearer ";
     @Value("${spring.security.oauth2.client.registration.naver.client-id}")
@@ -25,8 +26,10 @@ public class SocialService {
     @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
     private static String NAVER_CLIENT_SECRET;
 
-    public void checkUserInfo(String provider, String providerId, String accessToken) {
+    public void checkUserInfo(String provider, String encodedId, String encodedToken) {
         // TODO: ACCESS TOKEN 복호화
+        String providerId = authService.decode(encodedId);
+        String accessToken = authService.decode(encodedToken);
 
         String header = AUTH_TYPE + accessToken;
         String id = "";

--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/UserDetailsService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/UserDetailsService.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
-    @Autowired
     private final UserRepository userRepository;
 
     @Override

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -83,6 +83,7 @@ public enum Code {
     ALREADY_EXIST_SOCIAL_CONNECT(HttpStatus.CONFLICT, 409701, "해당 소셜 서비스에 연결된 계정이 이미 존재합니다."),
     OAUTH_FIND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500701, "소셜 인증 서버에서 에러가 발생했습니다."),
     OAUTH_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, 404702, "유효한 소셜 서버 Access Token이 아닙니다."),
+    INVALID_CRYPTOGRAM(HttpStatus.BAD_REQUEST, 400701, "유효하지 않은 암호문입니다."),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 소셜 로그인으로 받아오는 인증 정보 암호화
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
- 소셜 로그인 시, 유저 정보를 확인하기 위한 유저 식별값(`소셜 서버 Access Token` 및 `소셜 서버 userId`)에 대한 보안을 강화하기 위한 조치
  1. client에서 소셜 서버 로그인을 통해 알아낸 유저 식별값을 암호화하여 서버로 전송
  2. gusto 서버에서 암호화된 정보를 복호화한 후, 소셜 서버에 재확인하여 해당 정보가 유효한지 확인
  3. 유효한 정보라면, 암호화 상태의 소셜 서버 userId 를 서비스 DB에 저장함

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 해당 PR merge 후 `application.properties`에 추가되는 값들이 있으니 갱신 바랍니다. 
- 해당 PR merge 후 `WebSecurityConfig.java` 파일 갱신이 필요합니다.