### PR TITLE
Feat: 백엔드 테스트 시 토큰 발급을 위한 API

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
@@ -76,9 +76,15 @@ public class AuthController {
     * 테스트 시 필요한 토큰 발급을 위한 API
     *
     * */
-    @PostMapping("/{nickname}/token")
-    public ResponseEntity getTestToken(@RequestHeader("back-token") String backToken, @PathVariable("nickname") String nickname) {
+    @PostMapping("/token")
+    public ResponseEntity getTestToken(@RequestHeader("back-token") String backToken, @RequestParam("nickname") String nickname) {
+        String result = authService.getTestToken(backToken, nickname);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-AUTH-TOKEN", result);
+
         return ResponseEntity.ok()
+                .headers(headers)
                 .build();
     }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/AuthController.java
@@ -69,4 +69,16 @@ public class AuthController {
         return ResponseEntity.ok()
                 .body(result);
     }
+
+    /*
+    *
+    * auth 로그인이 불가능한 백엔드에서
+    * 테스트 시 필요한 토큰 발급을 위한 API
+    *
+    * */
+    @PostMapping("/{nickname}/token")
+    public ResponseEntity getTestToken(@RequestHeader("back-token") String backToken, @PathVariable("nickname") String nickname) {
+        return ResponseEntity.ok()
+                .build();
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/auth/service/AuthService.java
+++ b/gusto/src/main/java/com/umc/gusto/global/auth/service/AuthService.java
@@ -97,4 +97,8 @@ public class AuthService extends DefaultOAuth2UserService {
             throw new GeneralException(Code.INTERNAL_SEVER_ERROR);
         }
     }
+
+    public String getTestToken(String backToken, String nickname) {
+        return new String("");
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -84,6 +84,7 @@ public enum Code {
     OAUTH_FIND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500701, "소셜 인증 서버에서 에러가 발생했습니다."),
     OAUTH_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, 404702, "유효한 소셜 서버 Access Token이 아닙니다."),
     INVALID_CRYPTOGRAM(HttpStatus.BAD_REQUEST, 400701, "유효하지 않은 암호문입니다."),
+    INVALID_BACK_TOKEN(HttpStatus.BAD_REQUEST, 400702, "유효하지 않은 back-token 입니다."),
 
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST,49999, "테스트용 에러")
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 백엔드 테스트 시 토큰 발급을 위한 API
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 출시 준비로 백엔드에서 OAuth 로그인(소셜로그인)이 불가능한 상황으로, 백엔드에서 테스트 시 필요한 `access tokens`을 발급받기 위한 API
  - API 관련 설명은 노션의 API Sheet를 확인
  - `application.properties` 갱신됨 
