### PR TITLE
refactor: 가게 검색 시 좌표 정보도 응답 값으로 반환하도록 수정

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/review/repository/ReviewRepository.java
@@ -5,7 +5,7 @@ import com.umc.gusto.domain.review.model.FeedVO;
 import com.umc.gusto.domain.store.entity.Store;
 import com.umc.gusto.domain.user.entity.User;
 import com.umc.gusto.global.common.BaseEntity;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreInfoResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/model/response/GetStoreInfoResponse.java
@@ -14,5 +14,7 @@ public class GetStoreInfoResponse {
     String categoryString;
     String storeName;
     String address;
+    Double longitude;
+    Double latitude;
     String reviewImg;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/repository/StoreRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -17,5 +18,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("SELECT s FROM Store s WHERE s.storeStatus = 'ACTIVE' AND s.storeId < :cursorId " +
             "AND (REPLACE(s.storeName, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
             "OR REPLACE(s.categoryString, ' ', '') LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')))")
-    Page<Store> searchByStoreNameContains(String keyword, Long cursorId, PageRequest pageRequest);
+    Page<Store> searchByStoreNameContains(@Param("keyword") String keyword, @Param("cursorId") Long cursorId,
+                                          PageRequest pageRequest);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -3,8 +3,6 @@ package com.umc.gusto.domain.store.service;
 import com.umc.gusto.domain.myCategory.entity.Pin;
 import com.umc.gusto.domain.myCategory.repository.PinRepository;
 import com.umc.gusto.domain.review.entity.Review;
-import com.umc.gusto.domain.review.model.response.BasicViewResponse;
-import com.umc.gusto.domain.review.model.response.SearchFeedResponse;
 import com.umc.gusto.domain.review.repository.ReviewRepository;
 import com.umc.gusto.domain.store.entity.OpeningHours;
 import com.umc.gusto.domain.store.entity.Store;
@@ -323,6 +321,8 @@ public class StoreServiceImpl implements StoreService{
                             .storeName(result.getStoreName())
                             .categoryString(result.getCategoryString())
                             .address(result.getAddress())
+                            .latitude(result.getLatitude())
+                            .longitude(result.getLongitude())
                             .reviewImg(reviewImg)
                             .build();
                 })


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 : 
- [ ] 버그 수정 :
- [x] 리펙토링 : 가게 검색 시 좌표 정보도 응답 값으로 반환하도록 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
안드로이드에서 지도 표시할 때 좌표 위치가 필요

### 작업 내역

- searchStore의 응답값에 경도, 위도 좌표 정보 추가