### PR TITLE
feat : 사용자의 전체 찜 개수 조회

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/PagingResponse.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/model/response/PagingResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Setter
 @Builder
 public class PagingResponse {
+    private Integer allPinCnt;
     private boolean hasNext;
     private List<?> result;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -175,6 +175,8 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
             "AND t.townCode = :townCode " +
             "ORDER BY p.pinId DESC")
     List<Pin> findPinsByUserAndTownCodeAndPinIdDESC(User user, String townCode);
-    @Query("SELECT COUNT(p) FROM Pin p JOIN p.myCategory m WHERE p.user = :user AND p.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC'")
+    @Query("SELECT COUNT(p) FROM Pin p WHERE p.user = :user")
     Integer countPinByUser(User user);
+    @Query("SELECT COUNT(p) FROM Pin p JOIN p.myCategory m WHERE p.user = :user AND p.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC'")
+    Integer countPinByUserPublic(User user);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -123,13 +123,11 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
         p.updated_at AS updated_at
     FROM pin p
     JOIN store s ON p.store_id = s.store_id
-    WHERE p.user_id = UNHEX(REPLACE(:userId, '-', ''))
-      AND p.my_category_id = :myCategoryId
+    WHERE p.my_category_id = :myCategoryId
       AND ST_Distance_Sphere(s.location, ST_SRID(Point(:longitude, :latitude), 4326)) <= :radius
     ORDER BY p.pin_id DESC
 """, nativeQuery = true)
-    List<Pin> findPinsByUserAndMyCategoryIdWithinRadiusPinIdDESC(
-            @Param("userId") String userId,
+    List<Pin> findPinsByMyCategoryIdWithinRadiusPinIdDESC(
             @Param("myCategoryId") Long myCategoryId,
             @Param("longitude") Double longitude,
             @Param("latitude") Double latitude,
@@ -161,12 +159,10 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
         p.updated_at AS updated_at
     FROM pin p
     JOIN store s ON p.store_id = s.store_id
-    WHERE p.user_id = UNHEX(REPLACE(:userId, '-', ''))
-      AND ST_Distance_Sphere(s.location, ST_SRID(Point(:longitude, :latitude), 4326)) <= :radius
+    WHERE ST_Distance_Sphere(s.location, ST_SRID(Point(:longitude, :latitude), 4326)) <= :radius
     ORDER BY p.pin_id DESC
 """, nativeQuery = true)
-    List<Pin> findPinsByUserWithinRadiusPinIdDESC(
-            @Param("userId") String userId,
+    List<Pin> findPinsByRadiusPinIdDESC(
             @Param("longitude") Double longitude,
             @Param("latitude") Double latitude,
             @Param("radius") int radius

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/repository/PinRepository.java
@@ -175,4 +175,6 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
             "AND t.townCode = :townCode " +
             "ORDER BY p.pinId DESC")
     List<Pin> findPinsByUserAndTownCodeAndPinIdDESC(User user, String townCode);
+    @Query("SELECT COUNT(p) FROM Pin p JOIN p.myCategory m WHERE p.user = :user AND p.user.publishCategory = 'PUBLIC' AND m.publishCategory = 'PUBLIC'")
+    Integer countPinByUser(User user);
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -81,7 +81,9 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 })
                 .collect(Collectors.toList());
 
+        Integer allPinCnt = pinRepository.countPinByUser(user);    // 찜한 전체 개수
         return PagingResponse.builder()
+                .allPinCnt(allPinCnt)
                 .hasNext(myCategoryList.hasNext())
                 .result(result)
                 .build();

--- a/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/myCategory/service/MyCategoryServiceImpl.java
@@ -43,6 +43,8 @@ public class MyCategoryServiceImpl implements MyCategoryService {
     @Transactional(readOnly = true)
     public PagingResponse getAllMyCategory(User user, String nickname, String townCode, Long myCategoryId) {
         Page<MyCategory> myCategoryList;
+        Integer allPinCnt;
+
         if (nickname != null) {
             user = userRepository.findByNickname(nickname)      // 타 닉네임 조회
                     .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
@@ -51,13 +53,14 @@ public class MyCategoryServiceImpl implements MyCategoryService {
             } else {
                 myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPublic(user, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             }
+            allPinCnt = pinRepository.countPinByUserPublic(user);
         } else {    // 내 카테고리 조회
             if (myCategoryId != null) {
                 myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategoryPaging(user, myCategoryId, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             } else {
                 myCategoryList = myCategoryRepository.findByUserNicknameAndPublishCategory(user, Pageable.ofSize(MY_CATEGORY_PAGE_SIZE));
             }
-
+            allPinCnt = pinRepository.countPinByUser(user);
         }
 
         User finalUser = user;
@@ -81,7 +84,6 @@ public class MyCategoryServiceImpl implements MyCategoryService {
                 })
                 .collect(Collectors.toList());
 
-        Integer allPinCnt = pinRepository.countPinByUser(user);    // 찜한 전체 개수
         return PagingResponse.builder()
                 .allPinCnt(allPinCnt)
                 .hasNext(myCategoryList.hasNext())

--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -159,10 +159,10 @@ public class StoreServiceImpl implements StoreService{
 
         List<Pin> pins = new ArrayList<>();
         if (myCategoryIds == null || myCategoryIds.isEmpty()) {
-            pins = pinRepository.findPinsByUserWithinRadiusPinIdDESC(userId, longitude, latitude, radius);
+            pins = pinRepository.findPinsByRadiusPinIdDESC(longitude, latitude, radius);
         } else {
             for (Long myCategoryId : myCategoryIds) {
-                pins.addAll(pinRepository.findPinsByUserAndMyCategoryIdWithinRadiusPinIdDESC(userId, myCategoryId, longitude, latitude, radius));
+                pins.addAll(pinRepository.findPinsByMyCategoryIdWithinRadiusPinIdDESC(myCategoryId, longitude, latitude, radius));
             }
         }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 사용자의 전체 찜 개수 조회
- [ ] 버그 수정 :
- [x] 리펙토링 : 네이티브 쿼리 조회에 필요 없는 user_id 조건 삭제
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 페이지에 사용자의 전체 찜 개수를 조회하는 부분 추가
- 네이티브 쿼리 조회 시(위치 반경 카테고리 조회) 사용자 정보를 조회할 필요가 없어 user_id 조건 삭제

### 작업 내역

- PagingResponse에 사용자의 전체 찜 개수를 나타내는 allPinCnt 응답 필드를 추가
    - 타인/사용자 조회에 따른 countPinByUserPublic, countPinByUser 쿼리 두개 사용
- 네이티브 쿼리 조회에 필요 없는 user_id 조건 삭제
 

### 작업 후 기대 동작(스크린샷)
- 내 카테고리 전체 조회
<img width="1402" height="868" alt="image" src="https://github.com/user-attachments/assets/aaa9eb48-8917-4c58-b12e-a16ee5e5a915" />

- 타인의 카테고리 전체 조회
<img width="1275" height="740" alt="image" src="https://github.com/user-attachments/assets/081cb4c6-8d3d-4964-adeb-411fb42f79be" />

### PR 특이 사항

### Issue Number 

close: #341 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- '사용자의 전체 찜 개수 조회' 관련 코드