### PR TITLE
feat: 초대 코드 시스템 개편 (7일 뒤 만료 및 보안 강화)

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,8 +9,16 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.2.1/9d6ac9a2fa98598d1a38e9f06d6f0aab250cae2f/spring-boot-configuration-processor-3.2.1.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
         </processorPath>
+        <module name="gusto.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="gusto" options="-parameters" />
+      <module name="gusto.main" options="-parameters" />
+      <module name="gusto.test" options="-parameters" />
+    </option>
   </component>
 </project>

--- a/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/controller/GroupController.java
@@ -80,8 +80,9 @@ public class GroupController {
      * [GET] /groups/{groupId}/invitationCode
      */
     @GetMapping("/{groupId}/invitationCode")
-    public ResponseEntity<GetInvitationCodeResponse> getInvitationCode(@PathVariable Long groupId) {
-        GetInvitationCodeResponse getInvitationCode = groupService.getInvitationCode(groupId);
+    public ResponseEntity<GetInvitationCodeResponse> getInvitationCode(@AuthenticationPrincipal AuthUser authUser, @PathVariable Long groupId) {
+        User user = authUser.getUser();
+        GetInvitationCodeResponse getInvitationCode = groupService.getInvitationCode(user, groupId);
         return ResponseEntity.status(HttpStatus.OK).body(getInvitationCode);
     }
 

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
@@ -24,6 +24,6 @@ public class InvitationCode extends BaseTime {
     @JoinColumn(name = "groupId", nullable = false)
     private Group group;
 
-    @Column(columnDefinition = "VARCHAR(12)")
+    @Column(columnDefinition = "VARCHAR(255)")
     private String code;
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/entity/InvitationCode.java
@@ -24,6 +24,10 @@ public class InvitationCode extends BaseTime {
     @JoinColumn(name = "groupId", nullable = false)
     private Group group;
 
-    @Column(columnDefinition = "VARCHAR(255)")
+    @Column(columnDefinition = "VARCHAR(512)")
     private String code;
+
+    public void updateCode(String newCode){
+        this.code = newCode;
+    }
 }

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/GroupService.java
@@ -30,7 +30,7 @@ public interface GroupService {
     PagingResponse getAllGroupList(Long groupId, Long groupListId,User user);
 
     // 그룹 초대 코드 조회
-    GetInvitationCodeResponse getInvitationCode(Long groupId);
+    GetInvitationCodeResponse getInvitationCode(User user, Long groupId);
 
     // 그룹 소유권 이전
     TransferOwnershipResponse transferOwnership(User owner, Long groupId, TransferOwnershipRequest transferOwnershipRequest);

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/InviteCodeUtil.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/InviteCodeUtil.java
@@ -1,0 +1,104 @@
+package com.umc.gusto.domain.group.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.gusto.global.exception.Code;
+import com.umc.gusto.global.exception.GeneralException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.Objects;
+
+@Component
+public class InviteCodeUtil {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String SECRET;
+
+    private static final long EXPIRATION_HOURS = 24;
+    private static final int RANDOM_STRING_LENGTH = 10;
+
+    // 생성자 주입
+    public InviteCodeUtil(@Value("${invite.code.secret-key}") String secret) {
+        this.SECRET = secret;
+    }
+
+    // 내부에서 사용할 DTO
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class InviteCodePayload {
+        private Long groupId;
+        private Long exp;
+        private Long iat;
+        private String rnd;
+    }
+
+    // 초대 코드 생성 (DTO와 ObjectMapper 사용)
+    public String generateInviteCode(Long groupId) {
+        try {
+            long iat = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+            long exp = LocalDateTime.now().plusHours(EXPIRATION_HOURS).toEpochSecond(ZoneOffset.UTC);
+            // [테스트용 코드] 현재 시간에서 1초 뺌 (생성하자마자 만료됨)
+            //long exp = LocalDateTime.now().minusSeconds(1).toEpochSecond(ZoneOffset.UTC);
+            String rnd = RandomStringUtils.randomAlphanumeric(RANDOM_STRING_LENGTH);
+
+            InviteCodePayload payloadObject = new InviteCodePayload(groupId, exp, iat, rnd);
+            String payload = objectMapper.writeValueAsString(payloadObject);
+
+            String encodedPayload = Base64.getUrlEncoder().withoutPadding().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+            String signature = hmacSha256(encodedPayload, SECRET);
+            return encodedPayload + "." + signature;
+        } catch (Exception e) {
+            throw new GeneralException(Code.INTERNAL_SEVER_ERROR);
+        }
+    }
+
+    // 초대 코드 검증 및 groupId 추출
+    public Long validateAndGetGroupId(String inviteCode) {
+        try {
+            String[] parts = inviteCode.split("\\.");
+            if (parts.length != 2) {
+                throw new GeneralException(Code.INVALID_INVITE_CODE_FORMAT);
+            }
+
+            String encodedPayload = parts[0];
+            String signature = parts[1];
+
+            String expectedSig = hmacSha256(encodedPayload, SECRET);
+            if (!Objects.equals(expectedSig, signature)) {
+                throw new GeneralException(Code.INVITE_CODE_SIGNATURE_MISMATCH);
+            }
+
+            String payloadJson = new String(Base64.getUrlDecoder().decode(encodedPayload), StandardCharsets.UTF_8);
+            InviteCodePayload payload = objectMapper.readValue(payloadJson, InviteCodePayload.class);
+
+            if (LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) >= payload.getExp()) {
+                throw new GeneralException(Code.INVITE_CODE_EXPIRED);
+            }
+
+            return payload.getGroupId();
+        } catch (GeneralException e) {
+            throw e; // 이미 처리된 예외는 그대로 다시 던짐
+        } catch (Exception e) {
+            // JSON 파싱 오류 등 기타 모든 예외
+            throw new GeneralException(Code.INVALID_INVITE_CODE);
+        }
+    }
+
+    // HMAC SHA256 서명
+    private String hmacSha256(String data, String key) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] hash = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+}

--- a/gusto/src/main/java/com/umc/gusto/domain/group/service/InviteCodeUtil.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/group/service/InviteCodeUtil.java
@@ -23,7 +23,7 @@ public class InviteCodeUtil {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String SECRET;
 
-    private static final long EXPIRATION_HOURS = 24;
+    private static final long EXPIRATION_HOURS = 168;
     private static final int RANDOM_STRING_LENGTH = 10;
 
     // 생성자 주입

--- a/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
+++ b/gusto/src/main/java/com/umc/gusto/global/exception/Code.java
@@ -60,7 +60,11 @@ public enum Code {
     GROUPLIST_NOT_FROUND(HttpStatus.NOT_FOUND,403409,"존재하지 않는 그룹 내 상점입니다."),
     ALREADY_JOINED_GROUP(HttpStatus.BAD_REQUEST, 400410, "이미 해당 그룹에 참여한 유저입니다."),
     ALREADY_ADD_GROUP_LIST(HttpStatus.BAD_REQUEST, 400411,"이미 해당 그룹에 존재하는 그룹리스트입니다."),
-  
+    INVITE_CODE_EXPIRED(HttpStatus.BAD_REQUEST, 400412, "초대 코드가 만료되었습니다."),
+    INVALID_INVITE_CODE_FORMAT(HttpStatus.BAD_REQUEST, 400414, "초대 코드의 형식이 올바르지 않습니다."),
+    INVITE_CODE_SIGNATURE_MISMATCH(HttpStatus.BAD_REQUEST, 400415, "초대 코드가 위변조되었거나 손상되었습니다."),
+    INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, 400416, "초대 코드 정보를 읽을 수 없습니다."),
+
     //myCategory 관련 에러 +5
     MY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404501, "존재하지 않는 카테고리입니다."),
     PIN_NOT_FOUND(HttpStatus.NOT_FOUND, 404502,"존재하지 않는 찜 입니다"),


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 초대 코드 만료(일주일) 및 자동 재발급 기능
- [ ] 버그 수정 :
- [x] 리펙토링 : 초대 코드 생성/검증 로직 전면 개편 (단순 문자열 -> JWT 방식)
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 기존의 영구적인 초대 코드는 유출 시 보안 위험이 있고, 만료된 코드를 관리하기 어려웠습니다. 이를 해결하기 위해 7일 유효기간과 위변조 방지 서명(Signature)이 포함된 토큰형 초대 코드 시스템으로 전면 개편했습니다.

#### 💡 초대 코드 구조 설명
변경된 코드는 `Base64(Payload).Signature` 구조를 가지는 **자체 서명 토큰**입니다.
- **Payload**: `groupId`, `만료시간(exp)`, `발급시간(iat)` 정보를 담고 있어, DB 조회 전에 **코드 자체만으로 1차 검증**이 가능합니다.
- **Signature**: 서버의 **Secret Key**로 생성된 HMAC-SHA256 서명입니다. 사용자가 Payload(예: 만료시간)를 임의로 조작하면 서명이 깨지므로 **위변조를 원천 차단**합니다.

### 작업 내역
- **`InviteCodeUtil` 컴포넌트 구현**
    - `ObjectMapper`를 활용한 JSON Payload 생성 및 파싱
    - HMAC-SHA256 알고리즘 서명 생성 및 검증 로직
    - `application.properties`를 통한 Secret Key 주입 (보안 강화 / 기존에는 자바 코드 안에 하드코딩 되어 있었습니다.)

- **`GroupService` 로직 재설계**
    - **생성(`createGroup`)**: 그룹 생성 시 만료 시간(7days)이 설정된 토큰 발급
    - **자동 재발급(`getInvitationCode`)**: 그룹장이 코드 조회 시, 만료 여부를 체크하고 **만료되었다면 자동으로 새 코드로 갱신(Update)** 후 반환
    - **검증 순서 변경(`joinGroup`)**:
        - (AS-IS) `DB 조회` → `없으면 404 Not Found`
        - (TO-BE) **`Util 검증(시간/서명)` → `DB 조회`**
        - 이미 재발급되어 DB에서 사라진 만료 코드에 대해, 404(없음)가 아닌 **400(만료됨)** 에러를 명확하게 반환하여 UX 개선

- **에러 코드 세분화 (`Code.java`)**
    - `INVITE_CODE_EXPIRED (400)`: 만료된 코드
    - `INVALID_INVITE_CODE_FORMAT (400)`: 형식 오류
    - `INVITE_CODE_SIGNATURE_MISMATCH (400)`: 위변조 시도 감지

### 작업 후 기대 동작(스크린샷)

- **[성공] 그룹장이 만료된 코드 조회 시 → 자동 재발급 (200 OK)**

    - 그룹 생성
      <img width="1782" height="358" alt="image" src="https://github.com/user-attachments/assets/25bfa6ac-faa8-45b7-abff-f69c924670d4" />
    

    - 만료된 코드 조회 시 자동 재발급
       <img width="1372" height="651" alt="image" src="https://github.com/user-attachments/assets/32591601-188e-4fd1-afb5-1b5db47b3ff3" />


  
- **[실패] 유저가 만료된 코드로 참여 시도 시 → 만료 에러 (400 Bad Request)**
    
   <img width="1365" height="516" alt="image" src="https://github.com/user-attachments/assets/5373ce58-def5-4594-9aea-dc82c13f8348" />

- **[실패] 코드를 임의로 조작(위조)하여 시도 시 → 서명 불일치 에러 (400 Bad Request)**
    
    <img width="1364" height="530" alt="image" src="https://github.com/user-attachments/assets/15d45154-700d-4bca-aacc-3d880ef5793b" />

- **[실패] JWT 형식이 아닌 랜덤 문자열 입력 시 → 형식 오류 (400 Bad Request)**
   
    <img width="1371" height="538" alt="image" src="https://github.com/user-attachments/assets/134670e6-32d0-4f46-a13c-267b0e73772d" />


### PR 특이 사항

- DB 스키마 변경: 초대 코드의 길이가 늘어났으므로, 배포 서버 DB의 컬럼 길이 확장

### Issue Number 

close: #343 
