### PR TITLE
feat: '현재 지역의 찜한 식당 방문 여부 조회 API' 위경도 정보 추가 및 중복 제거 로직 적용

### DIFF
--- a/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
+++ b/gusto/src/main/java/com/umc/gusto/domain/store/service/StoreServiceImpl.java
@@ -216,8 +216,18 @@ public class StoreServiceImpl implements StoreService{
         List<GetStoreInfoResponse> visitedStoresInfo = new ArrayList<>();
         List<GetStoreInfoResponse> unvisitedStoresInfo = new ArrayList<>();
 
+        Set<Long> processedStoreIds = new HashSet<>();
+
         for (Pin pin : pins){
             Store store = pin.getStore();
+
+            // 이미 처리한 가게라면 건너뛰기
+            if (processedStoreIds.contains(store.getStoreId())) {
+                continue;
+            }
+            // 처리한 가게 ID 기록
+            processedStoreIds.add(store.getStoreId());
+
             Optional<Review> topReviewOptional = reviewRepository.findFirstByStoreOrderByLikedDesc(store);
             String reviewImg = topReviewOptional.map(Review::getImg1).orElse("");
             boolean hasVisited = reviewRepository.existsByStoreAndUserNickname(store, user.getNickname());
@@ -228,6 +238,8 @@ public class StoreServiceImpl implements StoreService{
                     .storeName(store.getStoreName())
                     .address(store.getAddress())
                     .reviewImg(reviewImg)
+                    .longitude(store.getLongitude())
+                    .latitude(store.getLatitude())
                     .build();
 
             if(!hasVisited){


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 찜한 식당 조회 시 위경도 데이터 반환
- [x] 버그 수정 : 식당 목록 중복 노출 문제 해결
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- **위경도 데이터 추가**: 프론트엔드 지도 기능 구현을 위해 `GetStoreInfoResponse`에 `longitude`, `latitude` 데이터를 매핑하여 반환하도록 수정했습니다.

- **중복 제거 로직 적용**: 기존 로직이 `Pin` 내역을 기준으로 순회하여, 한 유저가 같은 식당을 여러 번 찜했을 경우(혹은 데이터 문제로) 동일 식당이 중복 노출되는 문제가 있었습니다. 이를 해결하기 위해 `Set`을 도입하여 중복된 `storeId`를 필터링했습니다.

### 작업 내역

- **`StoreServiceImpl` 수정**
    - `getPinStoresByCategoryAndLocation` 메서드 내 `GetStoreInfoResponse` 빌더 패턴에 위경도 값 추가
    - `Set<Long> processedStoreIds`를 사용하여 이미 리스트에 추가된 식당은 `continue` 처리하는 중복 방지 로직 구현

### 작업 후 기대 동작(스크린샷)

**[성공] 찜한 식당 조회 시 위경도 포함 & 중복 없이 반환**
  <img width="1370" height="854" alt="image" src="https://github.com/user-attachments/assets/5d869d0e-dcf4-4b13-8516-4c1a9c825ea6" />


### Issue Number 

close: #345 
